### PR TITLE
fix: Check timestamps correctly

### DIFF
--- a/src/chronify/time_series_checker.py
+++ b/src/chronify/time_series_checker.py
@@ -5,8 +5,8 @@ import pandas as pd
 from chronify.exceptions import InvalidTable
 from chronify.models import TableSchema
 from chronify.sqlalchemy.functions import read_database
+from chronify.time_configs import DatetimeRange
 from chronify.time_range_generator_factory import make_time_range_generator
-from chronify.utils.sql import make_temp_view_name
 
 
 def check_timestamps(conn: Connection, table: Table, schema: TableSchema) -> None:
@@ -24,10 +24,11 @@ class TimeSeriesChecker:
         self._time_generator = make_time_range_generator(schema.time_config)
 
     def check_timestamps(self) -> None:
-        self._check_expected_timestamps_by_time_array()
-        self._check_expected_timestamps()
+        count = self._check_expected_timestamps()
+        self._check_null_consistency()
+        self._check_expected_timestamps_by_time_array(count)
 
-    def _check_expected_timestamps(self) -> None:
+    def _check_expected_timestamps(self) -> int:
         expected = self._time_generator.list_timestamps()
         time_columns = self._time_generator.list_time_columns()
         stmt = select(*(self._table.c[x] for x in time_columns)).distinct()
@@ -35,43 +36,83 @@ class TimeSeriesChecker:
             stmt = stmt.where(self._table.c[col].is_not(None))
         df = read_database(stmt, self._conn, self._schema.time_config)
         actual = self._time_generator.list_distinct_timestamps_from_dataframe(df)
+
+        if isinstance(self._schema.time_config, DatetimeRange):
+            expected = [pd.Timestamp(x) for x in expected]
         check_timestamp_lists(actual, expected)
+        return len(expected)
 
-    def _check_expected_timestamps_by_time_array(self) -> None:
-        tmp_name = make_temp_view_name()
-        self._run_timestamp_checks_on_tmp_table(tmp_name)
-        self._conn.execute(text(f"DROP TABLE IF EXISTS {tmp_name}"))
+    def _check_null_consistency(self) -> None:
+        # If any time column has a NULL, all time columns must have a NULL.
+        time_columns = self._time_generator.list_time_columns()
+        if len(time_columns) == 1:
+            return
 
-    def _run_timestamp_checks_on_tmp_table(self, table_name: str) -> None:
+        all_are_null = " AND ".join((f"{x} IS NULL" for x in time_columns))
+        any_are_null = " OR ".join((f"{x} IS NULL" for x in time_columns))
+        query_all = f"SELECT COUNT(*) FROM {self._schema.name} WHERE {all_are_null}"
+        query_any = f"SELECT COUNT(*) FROM {self._schema.name} WHERE {any_are_null}"
+        res_all = self._conn.execute(text(query_all)).fetchone()
+        assert res_all is not None
+        res_any = self._conn.execute(text(query_any)).fetchone()
+        assert res_any is not None
+        if res_all[0] != res_any[0]:
+            msg = (
+                "If any time columns have a NULL value for a row, all time columns in that "
+                "row must be NULL. "
+                f"Row count where all time values are NULL: {res_all[0]}. "
+                f"Row count where any time values are NULL: {res_any[0]}. "
+            )
+            raise InvalidTable(msg)
+
+    def _check_expected_timestamps_by_time_array(self, count: int) -> None:
         id_cols = ",".join(self._schema.time_array_id_columns)
-        filters = [f"{x} IS NOT NULL" for x in self._time_generator.list_time_columns()]
-        where_clause = " AND ".join(filters)
+        time_cols = ",".join(self._schema.time_config.list_time_columns())
+        # NULL consistency was checked above.
+        where_clause = f"{self._time_generator.list_time_columns()[0]} IS NOT NULL"
+        on_expr = " AND ".join([f"t1.{x} = t2.{x}" for x in self._schema.time_array_id_columns])
+        t1_id_cols = ",".join((f"t1.{x}" for x in self._schema.time_array_id_columns))
+
         query = f"""
-            CREATE TEMP TABLE {table_name} AS
-                SELECT
-                    {id_cols}
-                    ,COUNT(*) AS count_by_ta
+            WITH distinct_time_values_by_array AS (
+                SELECT DISTINCT {time_cols}, {id_cols}
+                FROM {self._schema.name}
+                WHERE {where_clause}
+            ),
+            t1 AS (
+                SELECT {id_cols}, COUNT(*) AS distinct_count_by_ta
+                FROM distinct_time_values_by_array
+                GROUP BY {id_cols}
+            ),
+            t2 AS (
+                SELECT {id_cols}, COUNT(*) AS count_by_ta
                 FROM {self._schema.name}
                 WHERE {where_clause}
                 GROUP BY {id_cols}
+            )
+            SELECT
+                t1.distinct_count_by_ta
+                ,t2.count_by_ta
+                ,{t1_id_cols}
+            FROM t1
+            JOIN t2
+            ON {on_expr}
         """
-        self._conn.execute(text(query))
-        query2 = f"SELECT COUNT(DISTINCT count_by_ta) AS counts FROM {table_name}"
-        result2 = self._conn.execute(text(query2)).fetchone()
-        assert result2 is not None
-
-        if result2[0] != 1:
-            msg = f"All time arrays must have the same length. There are {result2[0]} different lengths"
-            raise InvalidTable(msg)
-
-        query3 = f"SELECT DISTINCT count_by_ta AS counts FROM {table_name}"
-        result3 = self._conn.execute(text(query3)).fetchone()
-        assert result3 is not None
-        actual_count = result3[0]
-        expected_count = len(self._time_generator.list_timestamps())
-        if actual_count != expected_count:
-            msg = f"Time arrays must have length={expected_count}. Actual = {actual_count}"
-            raise InvalidTable(msg)
+        for result in self._conn.execute(text(query)).fetchall():
+            distinct_count_by_ta = result[0]
+            count_by_ta = result[1]
+            if not count_by_ta == count == distinct_count_by_ta:
+                id_vals = result[2:]
+                values = ", ".join(
+                    f"{x}={y}" for x, y in zip(self._schema.time_array_id_columns, id_vals)
+                )
+                msg = (
+                    f"The count of time values in each time array must be {count}, and each "
+                    "value must be distinct. "
+                    f"Time array identifiers: {values}."
+                    f"count = {count_by_ta}, distinct count = {distinct_count_by_ta}. "
+                )
+                raise InvalidTable(msg)
 
 
 def check_timestamp_lists(actual: list[pd.Timestamp], expected: list[pd.Timestamp]) -> None:

--- a/src/chronify/time_series_checker.py
+++ b/src/chronify/time_series_checker.py
@@ -5,7 +5,6 @@ import pandas as pd
 from chronify.exceptions import InvalidTable
 from chronify.models import TableSchema
 from chronify.sqlalchemy.functions import read_database
-from chronify.time_configs import DatetimeRange
 from chronify.time_range_generator_factory import make_time_range_generator
 
 
@@ -36,9 +35,6 @@ class TimeSeriesChecker:
             stmt = stmt.where(self._table.c[col].is_not(None))
         df = read_database(stmt, self._conn, self._schema.time_config)
         actual = self._time_generator.list_distinct_timestamps_from_dataframe(df)
-
-        if isinstance(self._schema.time_config, DatetimeRange):
-            expected = [pd.Timestamp(x) for x in expected]
         check_timestamp_lists(actual, expected)
         return len(expected)
 

--- a/tests/test_checker_representative_time.py
+++ b/tests/test_checker_representative_time.py
@@ -38,8 +38,22 @@ def test_one_week_per_month_by_hour_missing_data(
 ):
     df, _, schema = one_week_per_month_by_hour_table
     df2 = df.loc[df["hour"] != 0].copy()
-    error = (InvalidTable, "Time arrays must have length")
+    error = (InvalidTable, "Mismatch number of timestamps")
     ingest_data_and_check(iter_engines, df2, schema, error)
+
+
+def test_consistent_time_nulls(iter_engines: Engine, one_week_per_month_by_hour_table):
+    df, _, schema = one_week_per_month_by_hour_table
+    df.loc[len(df)] = [4.0, None, None, None, None]
+    error = ()
+    ingest_data_and_check(iter_engines, df, schema, error)
+
+
+def test_inconsistent_time_nulls(iter_engines: Engine, one_week_per_month_by_hour_table):
+    df, _, schema = one_week_per_month_by_hour_table
+    df.loc[len(df)] = [4.0, None, 1.0, 2.0, 0.345]
+    error = (InvalidTable, "If any time columns have a NULL value for a row")
+    ingest_data_and_check(iter_engines, df, schema, error)
 
 
 def test_one_weekday_day_and_one_weekend_day_per_month_by_hour(

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -106,9 +106,6 @@ def test_ingest_csv(iter_engines: Engine, tmp_path, generators_schema, use_time_
     # Adding the same rows should fail.
     with pytest.raises(InvalidTable):
         store.ingest_from_csv(new_file, src_schema2, dst_schema)
-        df = store.read_table(dst_schema)
-        assert len(df) == 8784 * 3 * 2
-        all(df.timestamp.unique() == expected_timestamps)
 
 
 def test_ingest_invalid_csv(iter_engines: Engine, tmp_path, generators_schema):

--- a/tests/test_time_series_checker.py
+++ b/tests/test_time_series_checker.py
@@ -32,6 +32,11 @@ def test_invalid_datetimes(iter_engines: Engine):
     _run_test(iter_engines, *_get_inputs_for_incorrect_datetimes())
 
 
+def test_invalid_datetime_length(iter_engines: Engine):
+    """Timestamps do not match the schema."""
+    _run_test(iter_engines, *_get_inputs_for_incorrect_datetime_length())
+
+
 def test_mismatched_time_array_lengths(iter_engines: Engine):
     """Some time arrays have different lengths."""
     _run_test(iter_engines, *_get_inputs_for_mismatched_time_array_lengths())
@@ -40,6 +45,16 @@ def test_mismatched_time_array_lengths(iter_engines: Engine):
 def test_incorrect_lengths(iter_engines: Engine):
     """All time arrays are consistent but have the wrong length."""
     _run_test(iter_engines, *_get_inputs_for_incorrect_lengths())
+
+
+def test_incorrect_time_arrays(iter_engines: Engine):
+    """The time arrays form a complete set but are individually incorrect."""
+    _run_test(iter_engines, *_get_inputs_for_incorrect_time_arrays())
+
+
+def test_incorrect_time_arrays_with_duplicates(iter_engines: Engine):
+    """The time arrays form a complete set but are individually incorrect."""
+    _run_test(iter_engines, *_get_inputs_for_incorrect_time_arrays_with_duplicates())
 
 
 def _run_test(
@@ -131,6 +146,30 @@ def _get_inputs_for_incorrect_datetimes() -> tuple[pd.DataFrame, ZoneInfo, int, 
     )
 
 
+def _get_inputs_for_incorrect_datetime_length() -> tuple[pd.DataFrame, ZoneInfo, int, str]:
+    data_tzinfo = ZoneInfo("America/New_York")
+    schema_tzinfo = ZoneInfo("MST")
+    df = pd.DataFrame(
+        {
+            "timestamp": [
+                datetime(2020, 1, 1, 0, tzinfo=data_tzinfo),
+                datetime(2020, 1, 1, 1, tzinfo=data_tzinfo),
+                datetime(2020, 1, 1, 2, tzinfo=data_tzinfo),
+                datetime(2020, 1, 1, 3, tzinfo=data_tzinfo),
+                datetime(2020, 1, 1, 4, tzinfo=data_tzinfo),
+            ],
+            "generator": ["gen1", "gen1", "gen1", "gen1", "gen1"],
+            "value": [1.0, 2.0, 3.0, 4.0, 5.0],
+        }
+    )
+    return (
+        df,
+        schema_tzinfo,
+        len(df) + 1,
+        "Mismatch number of timestamps",
+    )
+
+
 def _get_inputs_for_mismatched_time_array_lengths() -> tuple[pd.DataFrame, ZoneInfo, int, str]:
     tzinfo = ZoneInfo("EST")
     df = pd.DataFrame(
@@ -147,7 +186,7 @@ def _get_inputs_for_mismatched_time_array_lengths() -> tuple[pd.DataFrame, ZoneI
             "value": [1.0, 2.0, 3.0, 4.0, 5.0],
         }
     )
-    return df, tzinfo, 2, "All time arrays must have the same length."
+    return df, tzinfo, 2, "The count of time values in each time array must be"
 
 
 def _get_inputs_for_incorrect_lengths() -> tuple[pd.DataFrame, ZoneInfo, int, str]:
@@ -168,4 +207,63 @@ def _get_inputs_for_incorrect_lengths() -> tuple[pd.DataFrame, ZoneInfo, int, st
             "value": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
         }
     )
-    return df, tzinfo, 2, "Time arrays must have length="
+    return df, tzinfo, 2, "The count of time values in each time array must be"
+
+
+def _get_inputs_for_incorrect_time_arrays() -> tuple[pd.DataFrame, ZoneInfo, int, str]:
+    tzinfo = ZoneInfo("EST")
+    df = pd.DataFrame(
+        {
+            "timestamp": [
+                datetime(2020, 1, 1, 0, tzinfo=tzinfo),
+                datetime(2020, 1, 1, 1, tzinfo=tzinfo),
+                datetime(2020, 1, 1, 2, tzinfo=tzinfo),
+                datetime(2020, 1, 1, 3, tzinfo=tzinfo),
+                datetime(2020, 1, 1, 4, tzinfo=tzinfo),
+                datetime(2020, 1, 1, 5, tzinfo=tzinfo),
+            ],
+            "generator": ["gen1", "gen1", "gen1", "gen2", "gen2", "gen2"],
+            "value": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        }
+    )
+    return df, tzinfo, 6, "The count of time values in each time array must be"
+
+
+def _get_inputs_for_incorrect_time_arrays_with_duplicates() -> (
+    tuple[pd.DataFrame, ZoneInfo, int, str]
+):
+    tzinfo = ZoneInfo("EST")
+    df = pd.DataFrame(
+        {
+            "timestamp": [
+                datetime(2020, 1, 1, 0, tzinfo=tzinfo),
+                datetime(2020, 1, 1, 0, tzinfo=tzinfo),
+                datetime(2020, 1, 1, 1, tzinfo=tzinfo),
+                datetime(2020, 1, 1, 1, tzinfo=tzinfo),
+                datetime(2020, 1, 1, 2, tzinfo=tzinfo),
+                datetime(2020, 1, 1, 2, tzinfo=tzinfo),
+                datetime(2020, 1, 1, 3, tzinfo=tzinfo),
+                datetime(2020, 1, 1, 3, tzinfo=tzinfo),
+                datetime(2020, 1, 1, 4, tzinfo=tzinfo),
+                datetime(2020, 1, 1, 4, tzinfo=tzinfo),
+                datetime(2020, 1, 1, 5, tzinfo=tzinfo),
+                datetime(2020, 1, 1, 5, tzinfo=tzinfo),
+            ],
+            "generator": [
+                "gen1",
+                "gen1",
+                "gen1",
+                "gen1",
+                "gen1",
+                "gen1",
+                "gen2",
+                "gen2",
+                "gen2",
+                "gen2",
+                "gen2",
+                "gen2",
+            ],
+            "value": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0],
+        }
+    )
+    return df, tzinfo, 6, "The count of time values in each time array must be"


### PR DESCRIPTION
1. We were not properly checking timestamp count by time array and distinct timestamp count by time array.
2. We were not checking consistency of null values in time columns.