### PR TITLE
Add shift, roll, and time-wrap

### DIFF
--- a/src/chronify/datetime_range_generator.py
+++ b/src/chronify/datetime_range_generator.py
@@ -7,15 +7,27 @@ import pandas as pd
 from chronify.time import (
     LeapDayAdjustmentType,
 )
-from chronify.time_configs import DatetimeRange, adjust_timestamp_by_dst_offset
+from chronify.time_configs import (
+    DatetimeRange,
+    adjust_timestamp_by_dst_offset,
+    TimeBasedDataAdjustment,
+)
 from chronify.time_range_generator_base import TimeRangeGeneratorBase
 
 
 class DatetimeRangeGenerator(TimeRangeGeneratorBase):
     """Generates datetime ranges based on a DatetimeRange model."""
 
-    def __init__(self, model: DatetimeRange) -> None:
+    def __init__(
+        self,
+        model: DatetimeRange,
+        time_based_data_adjustment: TimeBasedDataAdjustment | None = None,
+    ) -> None:
         self._model = model
+        if time_based_data_adjustment is None:
+            self._adjustment = TimeBasedDataAdjustment()
+        else:
+            self._adjustment = time_based_data_adjustment
 
     def iter_timestamps(self) -> Generator[datetime, None, None]:
         for i in range(self._model.length):
@@ -35,20 +47,17 @@ class DatetimeRangeGenerator(TimeRangeGeneratorBase):
             month = cur.month
             day = cur.day
             if not (
-                self._model.time_based_data_adjustment.leap_day_adjustment
-                == LeapDayAdjustmentType.DROP_FEB29
+                self._adjustment.leap_day_adjustment == LeapDayAdjustmentType.DROP_FEB29
                 and month == 2
                 and day == 29
             ):
                 if not (
-                    self._model.time_based_data_adjustment.leap_day_adjustment
-                    == LeapDayAdjustmentType.DROP_DEC31
+                    self._adjustment.leap_day_adjustment == LeapDayAdjustmentType.DROP_DEC31
                     and month == 12
                     and day == 31
                 ):
                     if not (
-                        self._model.time_based_data_adjustment.leap_day_adjustment
-                        == LeapDayAdjustmentType.DROP_JAN1
+                        self._adjustment.leap_day_adjustment == LeapDayAdjustmentType.DROP_JAN1
                         and month == 1
                         and day == 1
                     ):

--- a/src/chronify/models.py
+++ b/src/chronify/models.py
@@ -62,6 +62,10 @@ class TableSchema(TableSchemaBase):
     @classmethod
     def check_name(cls, name: str) -> str:
         _check_name(name)
+        if name.lower() == "table":
+            # Avoid for DuckdB.
+            msg = f"Table schema cannot use {name=}."
+            raise ValueError(msg)
         return name
 
     @field_validator("value_column")

--- a/src/chronify/models.py
+++ b/src/chronify/models.py
@@ -63,7 +63,6 @@ class TableSchema(TableSchemaBase):
     def check_name(cls, name: str) -> str:
         _check_name(name)
         if name.lower() == "table":
-            # Avoid for DuckdB.
             msg = f"Table schema cannot use {name=}."
             raise ValueError(msg)
         return name
@@ -105,6 +104,47 @@ class PivotedTableSchema(TableSchemaBase):
 
     def list_columns(self) -> list[str]:
         return super().list_columns() + self.value_columns
+
+
+class MappingTableSchema(ChronifyBaseModel):
+    """Defines the schema for a mapping table for time conversion."""
+
+    name: Annotated[
+        str,
+        Field(description="Name of the table or view in the database.", frozen=True),
+    ]
+    time_configs: list[TimeConfig]
+    other_columns: list[str] = []
+
+    @field_validator("name")
+    @classmethod
+    def check_name(cls, name: str) -> str:
+        _check_name(name)
+        if name.lower() == "table":
+            msg = f"Table schema cannot use {name=}."
+            raise ValueError(msg)
+        return name
+
+    @field_validator("time_configs")
+    @classmethod
+    def check_time_configs(cls, time_configs: list[TimeConfig]) -> list[TimeConfig]:
+        for config in time_configs:
+            for column in config.list_time_columns():
+                _check_name(column)
+        return time_configs
+
+    @field_validator("other_columns")
+    @classmethod
+    def check_columns(cls, columns: list[str]) -> list[str]:
+        for column in columns:
+            _check_name(column)
+        return columns
+
+    def list_columns(self) -> list[str]:
+        time_columns = []
+        for config in self.time_configs:
+            time_columns += config.list_time_columns()
+        return time_columns + self.other_columns
 
 
 # TODO: print example tables here.

--- a/src/chronify/representative_time_range_generator.py
+++ b/src/chronify/representative_time_range_generator.py
@@ -11,14 +11,6 @@ from chronify.time import OneWeekPerMonthByHour, OneWeekdayDayOneWeekendDayPerMo
 from chronify.time_configs import RepresentativePeriodTime
 from chronify.time_range_generator_base import TimeRangeGeneratorBase
 
-# from chronify.time_utils import (
-#    build_time_ranges,
-#    filter_to_project_timestamps,
-#    shift_time_interval,
-#    time_difference,
-#    apply_time_wrap,
-# )
-
 
 logger = logging.getLogger(__name__)
 

--- a/src/chronify/sqlalchemy/functions.py
+++ b/src/chronify/sqlalchemy/functions.py
@@ -4,7 +4,7 @@ is very slow. This code attempts to bypass Python as much as possible through Ar
 in memory.
 """
 
-from typing import Any, Literal, TypeAlias
+from typing import Any, Literal, TypeAlias, Sequence
 
 import pandas as pd
 import polars as pl
@@ -44,7 +44,7 @@ def write_database(
     df: pd.DataFrame,
     conn: Connection,
     table_name: str,
-    configs: list[TimeBaseModel],
+    configs: Sequence[TimeBaseModel],
     if_table_exists: DbWriteMode = "append",
 ) -> None:
     """Write a Pandas DataFrame to the database.

--- a/src/chronify/store.py
+++ b/src/chronify/store.py
@@ -688,7 +688,7 @@ class Store:
             created_table = False
 
         try:
-            write_database(df, conn, schema.name, schema.time_config)
+            write_database(df, conn, schema.name, [schema.time_config])
         except Exception:
             if created_table:
                 table.drop(self._engine)

--- a/src/chronify/time_configs.py
+++ b/src/chronify/time_configs.py
@@ -20,13 +20,6 @@ from chronify.time import (
     RepresentativePeriodFormat,
     list_representative_time_columns,
 )
-# from chronify.time_utils import (
-#    build_time_ranges,
-#    filter_to_project_timestamps,
-#    shift_time_interval,
-#    time_difference,
-#    apply_time_wrap,
-# )
 
 
 logger = logging.getLogger(__name__)

--- a/src/chronify/time_configs.py
+++ b/src/chronify/time_configs.py
@@ -138,7 +138,6 @@ class DatetimeRange(TimeBaseModel):
     )
     length: int
     resolution: timedelta
-    time_based_data_adjustment: TimeBasedDataAdjustment = TimeBasedDataAdjustment()
 
     def is_time_zone_naive(self) -> bool:
         """Return True if the timestamps in the range do not have time zones."""
@@ -167,7 +166,6 @@ class IndexTimeRange(TimeBaseModel):
     length: int
     resolution: timedelta
     time_zone: TimeZone
-    time_based_data_adjustment: TimeBasedDataAdjustment
 
     def list_time_columns(self) -> list[str]:
         # TODO:

--- a/src/chronify/time_series_checker.py
+++ b/src/chronify/time_series_checker.py
@@ -118,8 +118,8 @@ def check_timestamp_lists(actual: list[pd.Timestamp], expected: list[pd.Timestam
             msg = f"Mismatch number of timestamps: actual: {len(actual)} vs. expected: {len(expected)}\n"
         else:
             msg = ""
-        missing = [x for x in expected if x not in actual]
-        extra = [x for x in actual if x not in expected]
+        missing = set(expected).difference(set(actual))
+        extra = set(actual).difference(set(expected))
         msg += "Actual timestamps do not match expected timestamps. \n"
         msg += f"Missing: {missing} \n"
         msg += f"Extra: {extra}"

--- a/src/chronify/time_series_checker.py
+++ b/src/chronify/time_series_checker.py
@@ -115,11 +115,12 @@ def check_timestamp_lists(actual: list[pd.Timestamp], expected: list[pd.Timestam
     match = actual == expected
     if not match:
         if len(actual) != len(expected):
-            msg1 = f"Mismatch number of timestamps: actual: {len(actual)} vs. expected: {len(expected)}"
-            raise InvalidTable(msg1)
+            msg = f"Mismatch number of timestamps: actual: {len(actual)} vs. expected: {len(expected)}\n"
+        else:
+            msg = ""
         missing = [x for x in expected if x not in actual]
         extra = [x for x in actual if x not in expected]
-        msg2 = "Actual timestamps do not match expected timestamps. \n"
-        msg2 += f"Missing: {missing} \n"
-        msg2 += f"Extra: {extra}"
-        raise InvalidTable(msg2)
+        msg += "Actual timestamps do not match expected timestamps. \n"
+        msg += f"Missing: {missing} \n"
+        msg += f"Extra: {extra}"
+        raise InvalidTable(msg)

--- a/src/chronify/time_series_mapper.py
+++ b/src/chronify/time_series_mapper.py
@@ -2,6 +2,7 @@ from sqlalchemy import Engine, MetaData
 from chronify.models import TableSchema
 
 from chronify.time_series_mapper_representative import MapperRepresentativeTimeToDatetime
+from chronify.time_series_mapper_datetime import MapperDatetimeToDatetime
 from chronify.time_configs import RepresentativePeriodTime, DatetimeRange
 
 
@@ -14,6 +15,10 @@ def map_time(
         to_schema.time_config, DatetimeRange
     ):
         MapperRepresentativeTimeToDatetime(engine, metadata, from_schema, to_schema).map_time()
+    elif isinstance(from_schema.time_config, DatetimeRange) and isinstance(
+        to_schema.time_config, DatetimeRange
+    ):
+        MapperDatetimeToDatetime(engine, metadata, from_schema, to_schema).map_time()
     else:
         msg = f"No mapping function for {from_schema.time_config.__class__=} >> {to_schema.time_config.__class__=}"
         raise NotImplementedError(msg)

--- a/src/chronify/time_series_mapper_base.py
+++ b/src/chronify/time_series_mapper_base.py
@@ -1,5 +1,100 @@
 import abc
+import logging
+from functools import reduce
+from operator import and_
+
+import pandas as pd
+from sqlalchemy import Engine, MetaData, Table, select, text
+
+from chronify.sqlalchemy.functions import write_database
+from chronify.models import TableSchema
+from chronify.exceptions import TableAlreadyExists
+from chronify.utils.sqlalchemy_table import create_table
+from chronify.time_series_checker import check_timestamps
+from chronify.time_configs import DatetimeRange
+
+logger = logging.getLogger(__name__)
 
 
 class TimeSeriesMapperBase(abc.ABC):
     """Maps time series data from one configuration to another."""
+
+
+def apply_mapping(
+    df_mapping: pd.DataFrame,
+    mapping_table_name: str,
+    from_schema: TableSchema,
+    to_schema: TableSchema,
+    engine: Engine,
+    metadata: MetaData,
+) -> None:
+    """
+    Apply mapping to create result table with process to clean up and roll back if checks fail
+    """
+    if mapping_table_name in metadata.tables:
+        msg = (
+            f"table {mapping_table_name} already exists, delete it or use a different table name."
+        )
+        raise TableAlreadyExists(msg)
+
+    time_configs = [to_schema.time_config]
+    if isinstance(from_schema.time_config, DatetimeRange):
+        from_time_config = from_schema.time_config.model_copy()
+        from_time_config.time_column = "from_" + from_time_config.time_column
+        time_configs.append(from_time_config)
+    try:
+        with engine.connect() as conn:
+            write_database(
+                df_mapping, conn, mapping_table_name, time_configs, if_table_exists="fail"
+            )
+            metadata.reflect(engine, views=True)
+            _apply_mapping(mapping_table_name, from_schema, to_schema, engine, metadata)
+            mapped_table = Table(to_schema.name, metadata)
+            try:
+                check_timestamps(conn, mapped_table, to_schema)
+            except Exception:
+                logger.exception(
+                    "check_timestamps failed on mapped table {}. Drop it", to_schema.name
+                )
+                conn.rollback()
+                raise
+            conn.commit()
+    finally:
+        if mapping_table_name in metadata.tables:
+            with engine.connect() as conn:
+                conn.execute(text(f"DROP TABLE {mapping_table_name}"))
+                conn.commit()
+            metadata.remove(Table(mapping_table_name, metadata))
+
+
+def _apply_mapping(
+    mapping_table_name: str,
+    from_schema: TableSchema,
+    to_schema: TableSchema,
+    engine: Engine,
+    metadata: MetaData,
+) -> None:
+    """Apply mapping to create result as a table according to_schema
+    - Columns used to join the from_table are prefixed with "from_" in the mapping table
+    """
+    left_table = Table(from_schema.name, metadata)
+    right_table = Table(mapping_table_name, metadata)
+    left_table_columns = [x.name for x in left_table.columns]
+    right_table_columns = [x.name for x in right_table.columns]
+
+    final_cols = set(to_schema.list_columns())
+    right_cols = set(right_table_columns).intersection(final_cols)
+    left_cols = final_cols - right_cols
+
+    select_stmt = [left_table.c[x] for x in left_cols]
+    select_stmt += [right_table.c[x] for x in right_cols]
+
+    keys = from_schema.time_config.list_time_columns()
+    # infer the use of time_zone
+    if "from_time_zone" in right_table_columns:
+        keys.append("time_zone")
+        assert "time_zone" in left_table_columns, f"time_zone not in table={from_schema.name}"
+
+    on_stmt = reduce(and_, (left_table.c[x] == right_table.c["from_" + x] for x in keys))
+    query = select(*select_stmt).select_from(left_table).join(right_table, on_stmt)
+    create_table(to_schema.name, query, engine, metadata)

--- a/src/chronify/time_series_mapper_base.py
+++ b/src/chronify/time_series_mapper_base.py
@@ -29,11 +29,9 @@ class TimeSeriesMapperBase(abc.ABC):
         # self._from_time_config = from_schema.time_config
         # self._to_time_config = to_schema.time_config
 
+    @abc.abstractmethod
     def check_schema_consistency(self) -> None:
         """Check that from_schema can produce to_schema."""
-        self._check_table_columns_producibility()
-        self._check_measurement_type_consistency()
-        self._check_time_interval_type()
 
     def _check_table_columns_producibility(self) -> None:
         """Check columns in destination table can be produced by source table."""

--- a/src/chronify/time_series_mapper_datetime.py
+++ b/src/chronify/time_series_mapper_datetime.py
@@ -1,0 +1,101 @@
+import logging
+
+from sqlalchemy import Engine, MetaData, Table
+
+from chronify.models import TableSchema
+from chronify.exceptions import (
+    ConflictingInputsError,
+    InvalidParameter,
+)
+from chronify.time_series_mapper_base import TimeSeriesMapperBase
+from chronify.utils.sqlalchemy_table import create_table
+from chronify.time_configs import DatetimeRange
+from chronify.time import TimeIntervalType
+
+logger = logging.getLogger(__name__)
+
+
+class MapperDatetimeToDatetime(TimeSeriesMapperBase):
+    def __init__(
+        self, engine: Engine, metadata: MetaData, from_schema: TableSchema, to_schema: TableSchema
+    ) -> None:
+        if not isinstance(from_schema.time_config, DatetimeRange):
+            msg = "source schema does not have DatetimeRange time config. Use a different mapper."
+            raise InvalidParameter(msg)
+        if not isinstance(to_schema.time_config, DatetimeRange):
+            msg = "destination schema does not have DatetimeRange time config. Use a different mapper."
+            raise InvalidParameter(msg)
+        self._from_time_config = from_schema.time_config
+        self._to_time_config = to_schema.time_config
+        self._from_schema = from_schema
+        self._to_schema = to_schema
+        self._engine = engine
+        self._metadata = metadata
+
+    def check_schema_consistency(self) -> None:
+        """Check that from_schema can produce to_schema."""
+        self._check_table_columns_producibility()
+        self._check_measurement_type_consistency()
+        self._check_time_interval_type()
+
+    def _check_table_columns_producibility(self) -> None:
+        """Check columns in destination table can be produced by source table."""
+        available_cols = self._from_schema.list_columns() + [self._to_time_config.time_column]
+        final_cols = self._to_schema.list_columns()
+        if diff := set(final_cols) - set(available_cols):
+            msg = f"Source table {self._from_schema.name} cannot produce the columns: {diff}"
+            raise ConflictingInputsError(msg)
+
+    def _check_measurement_type_consistency(self) -> None:
+        """Check that measurement_type is the same between schema."""
+        from_mt = self._from_schema.time_config.measurement_type
+        to_mt = self._to_schema.time_config.measurement_type
+        if from_mt != to_mt:
+            msg = f"Inconsistent measurement_types {from_mt=} vs. {to_mt=}"
+            raise ConflictingInputsError(msg)
+
+    def _check_time_interval_type(self) -> None:
+        """Check time interval type consistency."""
+        from_interval = self._from_time_config.interval_type
+        to_interval = self._from_time_config.interval_type
+        if TimeIntervalType.INSTANTANEOUS in (from_interval, to_interval) and (
+            from_interval != to_interval
+        ):
+            msg = "If instantaneous time interval is used, it must exist in both from_scheme and to_schema."
+            raise ConflictingInputsError(msg)
+
+    def _check_time_resolution(self) -> None:
+        if self._from_time_config.resolution != self._to_time_config.resolution:
+            msg = "Handling of changing time resolution is not supported yet."
+            raise NotImplementedError(msg)
+
+    def map_time(self) -> None:
+        """Convert time columns with from_schema to to_schema configuration."""
+        self.check_schema_consistency()
+
+        if self._from_time_config.interval_type != self._to_time_config.interval_type:
+            self._shift_time_interval()
+            # TODO - add handling for changing resolution
+
+    def _shift_time_interval(self) -> None:
+        table = Table(self._from_schema.name, self._metadata)
+        time_col = self._from_time_config.time_column
+        new_time_col = self._to_time_config.time_column
+        if new_time_col == time_col:
+            other_cols = [x.name for x in table.columns if x != time_col]
+        else:
+            other_cols = table.columns
+
+        match (self._from_time_config.interval_type, self._to_time_config.interval_type):
+            case (TimeIntervalType.PERIOD_BEGINNING, TimeIntervalType.PERIOD_ENDING):
+                op = "+"
+            case (TimeIntervalType.PERIOD_ENDING, TimeIntervalType.PERIOD_BEGINNING):
+                op = "-"
+            case _:
+                msg = f"Cannot handle from {self._from_time_config.interval_type} to {self._to_time_config.interval_type}"
+                raise InvalidParameter(msg)
+
+        delta_sec = self._from_time_config.resolution.seconds
+        query = f"SELECT {other_cols}, {time_col} {op} INTERVAL {delta_sec} SECONDS AS {new_time_col} FROM {self._from_schema.name}"
+
+        create_table(self._to_schema.name, query, self._engine, self._metadata)

--- a/src/chronify/time_series_mapper_datetime.py
+++ b/src/chronify/time_series_mapper_datetime.py
@@ -4,9 +4,7 @@ import pandas as pd
 from sqlalchemy import Engine, MetaData
 
 from chronify.models import TableSchema, MappingTableSchema
-from chronify.exceptions import (
-    InvalidParameter,
-)
+from chronify.exceptions import InvalidParameter, ConflictingInputsError
 from chronify.time_series_mapper_base import TimeSeriesMapperBase, apply_mapping
 from chronify.time_configs import DatetimeRange
 from chronify.time_range_generator_factory import make_time_range_generator
@@ -35,10 +33,22 @@ class MapperDatetimeToDatetime(TimeSeriesMapperBase):
         self._from_time_config = from_schema.time_config
         self._to_time_config = to_schema.time_config
 
-    def _check_time_resolution(self) -> None:
+    def check_schema_consistency(self) -> None:
+        """Check that from_schema can produce to_schema."""
+        self._check_table_columns_producibility()
+        self._check_measurement_type_consistency()
+        self._check_time_interval_type()
+        self._check_time_resolution_and_length()
+
+    def _check_time_resolution_and_length(self) -> None:
         if self._from_time_config.resolution != self._to_time_config.resolution:
             msg = "Handling of changing time resolution is not supported yet."
             raise NotImplementedError(msg)
+
+        flen, tlen = self._from_time_config.length, self._to_time_config.length
+        if flen != tlen:
+            msg = f"DatetimeRange length must match between from_schema and to_schema. {flen} vs. {tlen}"
+            raise ConflictingInputsError(msg)
 
     def map_time(self) -> None:
         """Convert time columns with from_schema to to_schema configuration."""
@@ -59,15 +69,23 @@ class MapperDatetimeToDatetime(TimeSeriesMapperBase):
         df = pd.DataFrame(
             {
                 from_time_col: make_time_range_generator(self._from_time_config).list_timestamps(),
-                to_time_col: to_time_data,
             }
         )
         if self._from_time_config.interval_type != self._to_time_config.interval_type:
+            # If from_tz or to_tz is naive, use tz_localize
+            from_timestamps = df[from_time_col]
+            fm_tz = self._from_time_config.start.tzinfo
+            to_tz = self._to_time_config.start.tzinfo
+            if None in (fm_tz, to_tz) and (fm_tz, to_tz) != (None, None):
+                from_timestamps = df[from_time_col].dt.tz_localize(to_tz)
             df[to_time_col] = roll_time_interval(
-                df[to_time_col],
+                from_timestamps,
                 self._from_time_config.interval_type,
                 self._to_time_config.interval_type,
+                to_time_data,
             )
+        else:
+            df[to_time_col] = make_time_range_generator(self._to_time_config).list_timestamps()
 
         from_time_config = self._from_time_config.model_copy()
         from_time_config.time_column = from_time_col

--- a/src/chronify/time_series_mapper_datetime.py
+++ b/src/chronify/time_series_mapper_datetime.py
@@ -3,14 +3,12 @@ import logging
 import pandas as pd
 from sqlalchemy import Engine, MetaData
 
-from chronify.models import TableSchema
+from chronify.models import TableSchema, MappingTableSchema
 from chronify.exceptions import (
-    ConflictingInputsError,
     InvalidParameter,
 )
 from chronify.time_series_mapper_base import TimeSeriesMapperBase, apply_mapping
 from chronify.time_configs import DatetimeRange
-from chronify.time import TimeIntervalType
 from chronify.time_range_generator_factory import make_time_range_generator
 from chronify.time_utils import roll_time_interval
 
@@ -21,50 +19,21 @@ class MapperDatetimeToDatetime(TimeSeriesMapperBase):
     def __init__(
         self, engine: Engine, metadata: MetaData, from_schema: TableSchema, to_schema: TableSchema
     ) -> None:
+        super().__init__(engine, metadata, from_schema, to_schema)
+        if from_schema == to_schema:
+            msg = (
+                f"From table schema is the same as to table schema. Nothing to do.\n{from_schema}"
+            )
+            logger.info(msg)
+            return
         if not isinstance(from_schema.time_config, DatetimeRange):
-            msg = "source schema does not have DatetimeRange time config. Use a different mapper."
+            msg = "Source schema does not have DatetimeRange time config. Use a different mapper."
             raise InvalidParameter(msg)
         if not isinstance(to_schema.time_config, DatetimeRange):
-            msg = "destination schema does not have DatetimeRange time config. Use a different mapper."
+            msg = "Destination schema does not have DatetimeRange time config. Use a different mapper."
             raise InvalidParameter(msg)
         self._from_time_config = from_schema.time_config
         self._to_time_config = to_schema.time_config
-        self._from_schema = from_schema
-        self._to_schema = to_schema
-        self._engine = engine
-        self._metadata = metadata
-
-    def check_schema_consistency(self) -> None:
-        """Check that from_schema can produce to_schema."""
-        self._check_table_columns_producibility()
-        self._check_measurement_type_consistency()
-        self._check_time_interval_type()
-
-    def _check_table_columns_producibility(self) -> None:
-        """Check columns in destination table can be produced by source table."""
-        available_cols = self._from_schema.list_columns() + [self._to_time_config.time_column]
-        final_cols = self._to_schema.list_columns()
-        if diff := set(final_cols) - set(available_cols):
-            msg = f"Source table {self._from_schema.name} cannot produce the columns: {diff}"
-            raise ConflictingInputsError(msg)
-
-    def _check_measurement_type_consistency(self) -> None:
-        """Check that measurement_type is the same between schema."""
-        from_mt = self._from_schema.time_config.measurement_type
-        to_mt = self._to_schema.time_config.measurement_type
-        if from_mt != to_mt:
-            msg = f"Inconsistent measurement_types {from_mt=} vs. {to_mt=}"
-            raise ConflictingInputsError(msg)
-
-    def _check_time_interval_type(self) -> None:
-        """Check time interval type consistency."""
-        from_interval = self._from_time_config.interval_type
-        to_interval = self._from_time_config.interval_type
-        if TimeIntervalType.INSTANTANEOUS in (from_interval, to_interval) and (
-            from_interval != to_interval
-        ):
-            msg = "If instantaneous time interval is used, it must exist in both from_scheme and to_schema."
-            raise ConflictingInputsError(msg)
 
     def _check_time_resolution(self) -> None:
         if self._from_time_config.resolution != self._to_time_config.resolution:
@@ -73,20 +42,14 @@ class MapperDatetimeToDatetime(TimeSeriesMapperBase):
 
     def map_time(self) -> None:
         """Convert time columns with from_schema to to_schema configuration."""
-        if self._from_schema == self._to_schema:
-            msg = "From table schema is the same as to table schema. Nothing to do.\n{self._from_schema}"
-            logger.info(msg)
-            return
         self.check_schema_consistency()
-
-        map_table_name = "mapping_table"
-        df = self._create_mapping()
+        df, mapping_schema = self._create_mapping()
         apply_mapping(
-            df, map_table_name, self._from_schema, self._to_schema, self._engine, self._metadata
+            df, mapping_schema, self._from_schema, self._to_schema, self._engine, self._metadata
         )
-        # TODO - add handling for changing resolution
+        # TODO - add handling for changing resolution - Issue #30
 
-    def _create_mapping(self) -> pd.DataFrame:
+    def _create_mapping(self) -> tuple[pd.DataFrame, MappingTableSchema]:
         """Create mapping dataframe
         Handles time interval type
         """
@@ -105,4 +68,15 @@ class MapperDatetimeToDatetime(TimeSeriesMapperBase):
                 self._from_time_config.interval_type,
                 self._to_time_config.interval_type,
             )
-        return df
+
+        from_time_config = self._from_time_config.model_copy()
+        from_time_config.time_column = from_time_col
+        mapping_schema = MappingTableSchema(
+            name="mapping_table",
+            time_configs=[
+                from_time_config,
+                self._to_time_config,
+            ],
+            other_columns=[],
+        )
+        return df, mapping_schema

--- a/src/chronify/time_series_mapper_datetime.py
+++ b/src/chronify/time_series_mapper_datetime.py
@@ -1,16 +1,18 @@
 import logging
 
-from sqlalchemy import Engine, MetaData, Table
+import pandas as pd
+from sqlalchemy import Engine, MetaData
 
 from chronify.models import TableSchema
 from chronify.exceptions import (
     ConflictingInputsError,
     InvalidParameter,
 )
-from chronify.time_series_mapper_base import TimeSeriesMapperBase
-from chronify.utils.sqlalchemy_table import create_table
+from chronify.time_series_mapper_base import TimeSeriesMapperBase, apply_mapping
 from chronify.time_configs import DatetimeRange
 from chronify.time import TimeIntervalType
+from chronify.time_range_generator_factory import make_time_range_generator
+from chronify.time_utils import roll_time_interval
 
 logger = logging.getLogger(__name__)
 
@@ -71,31 +73,36 @@ class MapperDatetimeToDatetime(TimeSeriesMapperBase):
 
     def map_time(self) -> None:
         """Convert time columns with from_schema to to_schema configuration."""
+        if self._from_schema == self._to_schema:
+            msg = "From table schema is the same as to table schema. Nothing to do.\n{self._from_schema}"
+            logger.info(msg)
+            return
         self.check_schema_consistency()
 
+        map_table_name = "mapping_table"
+        df = self._create_mapping()
+        apply_mapping(
+            df, map_table_name, self._from_schema, self._to_schema, self._engine, self._metadata
+        )
+        # TODO - add handling for changing resolution
+
+    def _create_mapping(self) -> pd.DataFrame:
+        """Create mapping dataframe
+        Handles time interval type
+        """
+        from_time_col = "from_" + self._from_time_config.time_column
+        to_time_col = self._to_time_config.time_column
+        to_time_data = make_time_range_generator(self._to_time_config).list_timestamps()
+        df = pd.DataFrame(
+            {
+                from_time_col: make_time_range_generator(self._from_time_config).list_timestamps(),
+                to_time_col: to_time_data,
+            }
+        )
         if self._from_time_config.interval_type != self._to_time_config.interval_type:
-            self._shift_time_interval()
-            # TODO - add handling for changing resolution
-
-    def _shift_time_interval(self) -> None:
-        table = Table(self._from_schema.name, self._metadata)
-        time_col = self._from_time_config.time_column
-        new_time_col = self._to_time_config.time_column
-        if new_time_col == time_col:
-            other_cols = [x.name for x in table.columns if x != time_col]
-        else:
-            other_cols = table.columns
-
-        match (self._from_time_config.interval_type, self._to_time_config.interval_type):
-            case (TimeIntervalType.PERIOD_BEGINNING, TimeIntervalType.PERIOD_ENDING):
-                op = "+"
-            case (TimeIntervalType.PERIOD_ENDING, TimeIntervalType.PERIOD_BEGINNING):
-                op = "-"
-            case _:
-                msg = f"Cannot handle from {self._from_time_config.interval_type} to {self._to_time_config.interval_type}"
-                raise InvalidParameter(msg)
-
-        delta_sec = self._from_time_config.resolution.seconds
-        query = f"SELECT {other_cols}, {time_col} {op} INTERVAL {delta_sec} SECONDS AS {new_time_col} FROM {self._from_schema.name}"
-
-        create_table(self._to_schema.name, query, self._engine, self._metadata)
+            df[to_time_col] = roll_time_interval(
+                df[to_time_col],
+                self._from_time_config.interval_type,
+                self._to_time_config.interval_type,
+            )
+        return df

--- a/src/chronify/time_series_mapper_representative.py
+++ b/src/chronify/time_series_mapper_representative.py
@@ -1,23 +1,18 @@
 import logging
-from functools import reduce
-from operator import and_
 
 import pandas as pd
-from sqlalchemy import Engine, MetaData, Table, select, text
+from sqlalchemy import Engine, MetaData, Table, select
 
-from chronify.sqlalchemy.functions import read_database, write_database
+from chronify.sqlalchemy.functions import read_database
 from chronify.models import TableSchema
 from chronify.exceptions import (
     MissingParameter,
     ConflictingInputsError,
-    TableAlreadyExists,
     InvalidParameter,
 )
 from chronify.time_range_generator_factory import make_time_range_generator
-from chronify.time_series_mapper_base import TimeSeriesMapperBase
-from chronify.utils.sqlalchemy_table import create_table
+from chronify.time_series_mapper_base import TimeSeriesMapperBase, apply_mapping
 from chronify.representative_time_range_generator import RepresentativePeriodTimeGenerator
-from chronify.time_series_checker import check_timestamps
 from chronify.time_configs import DatetimeRange, RepresentativePeriodTime
 from chronify.time_utils import shift_time_interval
 from chronify.time import TimeIntervalType
@@ -88,41 +83,16 @@ class MapperRepresentativeTimeToDatetime(TimeSeriesMapperBase):
         if not is_tz_naive:
             self._check_source_table_has_time_zone()
 
-        map_table_name = "map_table"
-        dfm = self._create_mapping(is_tz_naive)
-        if map_table_name in self._metadata.tables:
-            msg = (
-                f"table {map_table_name} already exists, delete it or use a different table name."
-            )
-            raise TableAlreadyExists(msg)
-
-        try:
-            with self._engine.connect() as conn:
-                write_database(
-                    dfm, conn, map_table_name, self._to_time_config, if_table_exists="fail"
-                )
-                self._metadata.reflect(self._engine, views=True)
-                self._apply_mapping(map_table_name)
-                mapped_table = Table(self._to_schema.name, self._metadata)
-                try:
-                    check_timestamps(conn, mapped_table, self._to_schema)
-                except Exception:
-                    logger.exception(
-                        "check_timestamps failed on mapped table {}. Drop it", self._to_schema.name
-                    )
-                    conn.rollback()
-                    raise
-                conn.commit()
-        finally:
-            if map_table_name in self._metadata.tables:
-                with self._engine.connect() as conn:
-                    conn.execute(text(f"DROP TABLE {map_table_name}"))
-                    conn.commit()
-                self._metadata.remove(Table(map_table_name, self._metadata))
+        map_table_name = "mapping_table"
+        df = self._create_mapping(is_tz_naive)
+        apply_mapping(
+            df, map_table_name, self._from_schema, self._to_schema, self._engine, self._metadata
+        )
 
     def _create_mapping(self, is_tz_naive: bool) -> pd.DataFrame:
         """Create mapping dataframe
-        Handles time interval type
+        - Handles time interval type adjustment
+        - Columns used to join the from_table are prefixed with "from_"
         """
         timestamp_generator = make_time_range_generator(self._to_time_config)
 
@@ -131,6 +101,8 @@ class MapperRepresentativeTimeToDatetime(TimeSeriesMapperBase):
 
         if self._from_time_config.interval_type != self._to_time_config.interval_type:
             time_col = "mapping_" + to_time_col
+            # mapping works backward for representative time
+            # shift is correct here for extracting time info
             dft[time_col] = shift_time_interval(
                 dft[to_time_col],
                 self._to_time_config.interval_type,
@@ -139,8 +111,9 @@ class MapperRepresentativeTimeToDatetime(TimeSeriesMapperBase):
         else:
             time_col = to_time_col
 
+        from_columns = self._from_time_config.list_time_columns()
         if is_tz_naive:
-            dfm = self._generator.create_tz_naive_mapping_dataframe(dft, time_col)
+            df = self._generator.create_tz_naive_mapping_dataframe(dft, time_col)
         else:
             with self._engine.connect() as conn:
                 table = Table(self._from_schema.name, self._metadata)
@@ -152,31 +125,8 @@ class MapperRepresentativeTimeToDatetime(TimeSeriesMapperBase):
                 time_zones = read_database(stmt, conn, self._from_time_config)[
                     "time_zone"
                 ].to_list()
-            dfm = self._generator.create_tz_aware_mapping_dataframe(dft, time_col, time_zones)
-        return dfm
+            df = self._generator.create_tz_aware_mapping_dataframe(dft, time_col, time_zones)
+            from_columns.append("time_zone")
 
-    def _apply_mapping(self, map_table_name: str) -> None:
-        """Apply mapping to create result as a table according to_schema"""
-        left_table = Table(self._from_schema.name, self._metadata)
-        right_table = Table(map_table_name, self._metadata)
-        left_table_columns = [x.name for x in left_table.columns]
-        right_table_columns = [x.name for x in right_table.columns]
-
-        final_cols = set(self._to_schema.list_columns())
-        left_cols = set(left_table_columns).intersection(final_cols)
-        right_cols = final_cols - left_cols
-
-        select_stmt = [left_table.c[x] for x in left_cols]
-        select_stmt += [right_table.c[x] for x in right_cols]
-
-        keys = self._from_time_config.list_time_columns()
-        if not self._to_time_config.is_time_zone_naive():
-            keys.append("time_zone")
-            assert (
-                "time_zone" in left_table_columns
-            ), f"time_zone not in table={self._from_schema.name}"
-            assert "time_zone" in right_table_columns, f"time_zone not in table={map_table_name}"
-
-        on_stmt = reduce(and_, (left_table.c[x] == right_table.c[x] for x in keys))
-        query = select(*select_stmt).select_from(left_table).join(right_table, on_stmt)
-        create_table(self._to_schema.name, query, self._engine, self._metadata)
+        df = df.rename(columns={x: "from_" + x for x in from_columns})
+        return df

--- a/src/chronify/time_series_mapper_representative.py
+++ b/src/chronify/time_series_mapper_representative.py
@@ -63,7 +63,7 @@ class MapperRepresentativeTimeToDatetime(TimeSeriesMapperBase):
 
         if self._from_time_config.interval_type != self._to_time_config.interval_type:
             time_col = "to_" + to_time_col
-            # mapping works backward for representative time by
+            # Mapping works backward for representative time by
             # shifting interval type of to_time_config to match
             # from_time_config before extracting time info
             dft[time_col] = shift_time_interval(
@@ -75,7 +75,6 @@ class MapperRepresentativeTimeToDatetime(TimeSeriesMapperBase):
             time_col = to_time_col
 
         from_columns = self._from_time_config.list_time_columns()
-        other_columns = []
         if is_tz_naive:
             df = self._generator.create_tz_naive_mapping_dataframe(dft, time_col)
         else:
@@ -91,15 +90,14 @@ class MapperRepresentativeTimeToDatetime(TimeSeriesMapperBase):
                 ].to_list()
             df = self._generator.create_tz_aware_mapping_dataframe(dft, time_col, time_zones)
             from_columns.append("time_zone")
-            other_columns.append("time_zone")
 
         df = df.rename(columns={x: "from_" + x for x in from_columns})
 
         mapping_schema = MappingTableSchema(
             name="mapping_table",
             time_configs=[
-                self._to_time_config,  # only needs to pass DatetimeRange
+                self._to_time_config,  # only DatetimeRange
             ],
-            other_columns=other_columns,
+            other_columns=from_columns,  # passing representative time here
         )
         return df, mapping_schema

--- a/src/chronify/time_series_mapper_representative.py
+++ b/src/chronify/time_series_mapper_representative.py
@@ -33,6 +33,12 @@ class MapperRepresentativeTimeToDatetime(TimeSeriesMapperBase):
         self._from_time_config = from_schema.time_config
         self._to_time_config = to_schema.time_config
 
+    def check_schema_consistency(self) -> None:
+        """Check that from_schema can produce to_schema."""
+        self._check_table_columns_producibility()
+        self._check_measurement_type_consistency()
+        self._check_time_interval_type()
+
     def _check_source_table_has_time_zone(self) -> None:
         """Check source table has time_zone column."""
         if "time_zone" not in self._from_schema.list_columns():

--- a/src/chronify/time_utils.py
+++ b/src/chronify/time_utils.py
@@ -1,0 +1,39 @@
+"""Functions related to time"""
+
+import logging
+
+import numpy as np
+
+import pandas as pd
+
+from chronify.time import (
+    TimeIntervalType,
+)
+from chronify.exceptions import InvalidParameter
+
+logger = logging.getLogger(__name__)
+
+
+def shift_time_interval(
+    df: pd.Series, from_interval_type: TimeIntervalType, to_interval_type: TimeIntervalType
+) -> pd.Series:
+    """Shift pandas timeseries by time interval based on interval type."""
+    assert (
+        from_interval_type != to_interval_type
+    ), f"from_ and to_interval_type are the same: {from_interval_type}"
+    arr = np.sort(df)
+    freqs = set((np.roll(arr, -1) - arr)[:-1])
+    assert len(freqs), f"Timeseries has more than one frequency, {freqs}"
+    freq = list(freqs)[0]
+
+    match (from_interval_type, to_interval_type):
+        case (TimeIntervalType.PERIOD_BEGINNING, TimeIntervalType.PERIOD_ENDING):
+            # shift time forward, 1am pd-beginning >> 2am pd-ending
+            mult = 1
+        case (TimeIntervalType.PERIOD_ENDING, TimeIntervalType.PERIOD_BEGINNING):
+            # shift time backward
+            mult = -1
+        case _:
+            msg = f"Cannot handle from {from_interval_type} to {to_interval_type}"
+            raise InvalidParameter(msg)
+    return df + freq * mult

--- a/src/chronify/time_utils.py
+++ b/src/chronify/time_utils.py
@@ -2,7 +2,6 @@
 
 import logging
 import numpy as np
-from typing import Any
 
 import pandas as pd
 
@@ -15,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 def shift_time_interval(
-    df: "pd.Series[pd.Timestamp]",
+    dfs: "pd.Series[pd.Timestamp]",
     from_interval_type: TimeIntervalType,
     to_interval_type: TimeIntervalType,
 ) -> "pd.Series[pd.Timestamp]":
@@ -23,10 +22,10 @@ def shift_time_interval(
     assert (
         from_interval_type != to_interval_type
     ), f"from_ and to_interval_type are the same: {from_interval_type}"
-    arr = np.sort(df)
+    arr = np.sort(dfs)
     freqs = set((np.roll(arr, -1) - arr)[:-1])
     assert len(freqs), f"Timeseries has more than one frequency, {freqs}"
-    freq: pd.Timedelta = list(freqs)[0]
+    freq: np.timedelta64 = next(iter(freqs))
 
     match (from_interval_type, to_interval_type):
         case (TimeIntervalType.PERIOD_BEGINNING, TimeIntervalType.PERIOD_ENDING):
@@ -38,49 +37,45 @@ def shift_time_interval(
         case _:
             msg = f"Cannot handle from {from_interval_type} to {to_interval_type}"
             raise InvalidParameter(msg)
-    return df + freq * mult
-
-
-def roll_time_interval(
-    df: "pd.Series[pd.Timestamp]",
-    from_interval_type: TimeIntervalType,
-    to_interval_type: TimeIntervalType,
-) -> np.typing.NDArray[Any]:
-    """Roll pandas timeseries by time interval based on interval type with np.roll(),
-    which includes time-wrapping.
-    """
-    assert (
-        from_interval_type != to_interval_type
-    ), f"from_ and to_interval_type are the same: {from_interval_type}"
-    match (from_interval_type, to_interval_type):
-        case (TimeIntervalType.PERIOD_BEGINNING, TimeIntervalType.PERIOD_ENDING):
-            # shift time forward, 1am pd-beginning >> 2am pd-ending
-            shift = -1
-        case (TimeIntervalType.PERIOD_ENDING, TimeIntervalType.PERIOD_BEGINNING):
-            # shift time backward
-            shift = 1
-        case _:
-            msg = f"Cannot handle from {from_interval_type} to {to_interval_type}"
-            raise InvalidParameter(msg)
-    return np.roll(df, shift)
+    return dfs + freq * mult
 
 
 def wrap_timestamps(
-    df: "pd.Series[pd.Timestamp]", to_timestamps: list[pd.Timestamp]
+    dfs: "pd.Series[pd.Timestamp]", to_timestamps: list[pd.Timestamp]
 ) -> "pd.Series[pd.Timestamp]":
-    """Wrap pandas timeseries so it conforms to a list of timestamps."""
+    """Wrap pandas timeseries so it stays within a list of timestamps.
+    Example usage:
+    dfs = pd.Series([2018-12-31 22:00, 2018-12-31 23:00, ..., 2019-12-31 21:00])
+    to_timestamps = [2019-01-01 00:00, ..., 2019-12-31 23:00]
+    df2 = wrap_timestamps(dfs, to_timstamps)
+    df2 => pd.Series([2019-12-31 22:00, 2019-12-31 23:00, ..., 2019-12-31 21:00])
+    """
     arr = np.sort(np.array(to_timestamps))
     freqs = set((np.roll(arr, -1) - arr)[:-1])
     assert len(freqs), f"Timeseries has more than one frequency, {freqs}"
-    freq = list(freqs)[0]
+    freq = next(iter(freqs))
 
     tmin, tmax = arr[0], arr[-1]
     tdelta = tmax - tmin + freq
-    df2 = df.copy()
-    lower_cond = df < tmin
+    dfs2 = dfs.copy()
+    lower_cond = dfs < tmin
     if lower_cond.sum() > 0:
-        df2.loc[lower_cond] += tdelta
-    upper_cond = df > tmax
+        dfs2.loc[lower_cond] += tdelta
+    upper_cond = dfs > tmax
     if upper_cond.sum() > 0:
-        df2.loc[upper_cond] -= tdelta
-    return df2
+        dfs2.loc[upper_cond] -= tdelta
+    return dfs2
+
+
+def roll_time_interval(
+    dfs: "pd.Series[pd.Timestamp]",
+    from_interval_type: TimeIntervalType,
+    to_interval_type: TimeIntervalType,
+) -> "pd.Series[pd.Timestamp]":
+    """Roll pandas timeseries by shifting time interval based on interval type and
+    wrapping timestamps
+    """
+    to_timestamps = dfs.tolist()
+    dfs = shift_time_interval(dfs, from_interval_type, to_interval_type)
+    dfs = wrap_timestamps(dfs, to_timestamps)
+    return dfs

--- a/src/chronify/time_utils.py
+++ b/src/chronify/time_utils.py
@@ -18,7 +18,25 @@ def shift_time_interval(
     from_interval_type: TimeIntervalType,
     to_interval_type: TimeIntervalType,
 ) -> "pd.Series[pd.Timestamp]":
-    """Shift pandas timeseries by time interval based on interval type."""
+    """Shift pandas timeseries by time interval based on interval type.
+
+    Example:
+    >>> dfs = pd.Series(pd.date_range("2018-12-31 22:00", periods=4, freq="h"))
+    0   2018-12-31 22:00:00
+    1   2018-12-31 23:00:00
+    2   2019-01-01 00:00:00
+    3   2019-01-01 01:00:00
+    dtype: datetime64[ns]
+
+    >>> dfs2 = shift_time_interval(
+    ...     dfs, TimeIntervalType.PERIOD_BEGINNING, TimeIntervalType.PERIOD_ENDING
+    ... )
+    0   2018-12-31 23:00:00
+    1   2019-01-01 00:00:00
+    2   2019-01-01 01:00:00
+    3   2019-01-01 02:00:00
+    dtype: datetime64[ns]
+    """
     assert (
         from_interval_type != to_interval_type
     ), f"from_ and to_interval_type are the same: {from_interval_type}"
@@ -44,11 +62,24 @@ def wrap_timestamps(
     dfs: "pd.Series[pd.Timestamp]", to_timestamps: list[pd.Timestamp]
 ) -> "pd.Series[pd.Timestamp]":
     """Wrap pandas timeseries so it stays within a list of timestamps.
-    Example usage:
-    dfs = pd.Series([2018-12-31 22:00, 2018-12-31 23:00, ..., 2019-12-31 21:00])
-    to_timestamps = [2019-01-01 00:00, ..., 2019-12-31 23:00]
-    df2 = wrap_timestamps(dfs, to_timstamps)
-    df2 => pd.Series([2019-12-31 22:00, 2019-12-31 23:00, ..., 2019-12-31 21:00])
+
+    Example:
+    >>> dfs = pd.Series(pd.date_range("2018-12-31 22:00", periods=4, freq="h"))
+    0   2018-12-31 22:00:00
+    1   2018-12-31 23:00:00
+    2   2019-01-01 00:00:00
+    3   2019-01-01 01:00:00
+    dtype: datetime64[ns]
+
+    >>> to_timestamps = pd.date_range("2019-01-01 00:00", periods=4, freq="h").tolist()
+    [Timestamp('2019-01-01 00:00:00'), Timestamp('2019-01-01 01:00:00'), Timestamp('2019-01-01 02:00:00'), Timestamp('2019-01-01 03:00:00')]
+
+    >>> dfs2 = wrap_timestamps(dfs, to_timestamps)
+    0   2019-01-01 02:00:00
+    1   2019-01-01 03:00:00
+    2   2019-01-01 00:00:00
+    3   2019-01-01 01:00:00
+    dtype: datetime64[ns]
     """
     arr = np.sort(np.array(to_timestamps))
     freqs = set((np.roll(arr, -1) - arr)[:-1])
@@ -71,11 +102,31 @@ def roll_time_interval(
     dfs: "pd.Series[pd.Timestamp]",
     from_interval_type: TimeIntervalType,
     to_interval_type: TimeIntervalType,
+    to_timestamps: list[pd.Timestamp],
 ) -> "pd.Series[pd.Timestamp]":
     """Roll pandas timeseries by shifting time interval based on interval type and
     wrapping timestamps
+
+    Example:
+    >>> dfs = pd.Series(pd.date_range("2018-12-31 22:00", periods=4, freq="h"))
+    0   2018-12-31 22:00:00
+    1   2018-12-31 23:00:00
+    2   2019-01-01 00:00:00
+    3   2019-01-01 01:00:00
+    dtype: datetime64[ns]
+
+    >>> to_timestamps = pd.date_range("2019-01-01 00:00", periods=4, freq="h").tolist()
+    [Timestamp('2019-01-01 00:00:00'), Timestamp('2019-01-01 01:00:00'), Timestamp('2019-01-01 02:00:00'), Timestamp('2019-01-01 03:00:00')]
+
+    >>> dfs2 = roll_time_interval(
+    ...     dfs, TimeIntervalType.PERIOD_BEGINNING, TimeIntervalType.PERIOD_ENDING, to_timestamps
+    ... )
+    0   2019-01-01 03:00:00
+    1   2019-01-01 00:00:00
+    2   2019-01-01 01:00:00
+    3   2019-01-01 02:00:00
+    dtype: datetime64[ns]
     """
-    to_timestamps = dfs.tolist()
     dfs = shift_time_interval(dfs, from_interval_type, to_interval_type)
     dfs = wrap_timestamps(dfs, to_timestamps)
     return dfs

--- a/src/chronify/time_utils.py
+++ b/src/chronify/time_utils.py
@@ -37,3 +37,44 @@ def shift_time_interval(
             msg = f"Cannot handle from {from_interval_type} to {to_interval_type}"
             raise InvalidParameter(msg)
     return df + freq * mult
+
+
+def roll_time_interval(
+    df: pd.Series, from_interval_type: TimeIntervalType, to_interval_type: TimeIntervalType
+) -> pd.Series:
+    """Roll pandas timeseries by time interval based on interval type with np.roll(),
+    which includes time-wrapping.
+    """
+    assert (
+        from_interval_type != to_interval_type
+    ), f"from_ and to_interval_type are the same: {from_interval_type}"
+    match (from_interval_type, to_interval_type):
+        case (TimeIntervalType.PERIOD_BEGINNING, TimeIntervalType.PERIOD_ENDING):
+            # shift time forward, 1am pd-beginning >> 2am pd-ending
+            shift = -1
+        case (TimeIntervalType.PERIOD_ENDING, TimeIntervalType.PERIOD_BEGINNING):
+            # shift time backward
+            shift = 1
+        case _:
+            msg = f"Cannot handle from {from_interval_type} to {to_interval_type}"
+            raise InvalidParameter(msg)
+    return np.roll(df, shift)
+
+
+def wrap_timestamps(df: pd.Series, to_timestamps: list[pd.Timestamp]) -> pd.Series:
+    """Wrap pandas timeseries so it conforms to a list of timestamps."""
+    arr = np.sort(to_timestamps)
+    freqs = set((np.roll(arr, -1) - arr)[:-1])
+    assert len(freqs), f"Timeseries has more than one frequency, {freqs}"
+    freq = list(freqs)[0]
+
+    tmin, tmax = arr[0], arr[-1]
+    tdelta = tmax - tmin + freq
+    df2 = df.copy()
+    lower_cond = df < tmin
+    if lower_cond.sum() > 0:
+        df2.loc[lower_cond] += tdelta
+    upper_cond = df > tmax
+    if upper_cond.sum() > 0:
+        df2.loc[upper_cond] -= tdelta
+    return df2

--- a/src/chronify/time_utils.py
+++ b/src/chronify/time_utils.py
@@ -1,8 +1,8 @@
 """Functions related to time"""
 
 import logging
-
 import numpy as np
+from typing import Any
 
 import pandas as pd
 
@@ -15,8 +15,10 @@ logger = logging.getLogger(__name__)
 
 
 def shift_time_interval(
-    df: pd.Series, from_interval_type: TimeIntervalType, to_interval_type: TimeIntervalType
-) -> pd.Series:
+    df: "pd.Series[pd.Timestamp]",
+    from_interval_type: TimeIntervalType,
+    to_interval_type: TimeIntervalType,
+) -> "pd.Series[pd.Timestamp]":
     """Shift pandas timeseries by time interval based on interval type."""
     assert (
         from_interval_type != to_interval_type
@@ -24,7 +26,7 @@ def shift_time_interval(
     arr = np.sort(df)
     freqs = set((np.roll(arr, -1) - arr)[:-1])
     assert len(freqs), f"Timeseries has more than one frequency, {freqs}"
-    freq = list(freqs)[0]
+    freq: pd.Timedelta = list(freqs)[0]
 
     match (from_interval_type, to_interval_type):
         case (TimeIntervalType.PERIOD_BEGINNING, TimeIntervalType.PERIOD_ENDING):
@@ -40,8 +42,10 @@ def shift_time_interval(
 
 
 def roll_time_interval(
-    df: pd.Series, from_interval_type: TimeIntervalType, to_interval_type: TimeIntervalType
-) -> pd.Series:
+    df: "pd.Series[pd.Timestamp]",
+    from_interval_type: TimeIntervalType,
+    to_interval_type: TimeIntervalType,
+) -> np.typing.NDArray[Any]:
     """Roll pandas timeseries by time interval based on interval type with np.roll(),
     which includes time-wrapping.
     """
@@ -61,9 +65,11 @@ def roll_time_interval(
     return np.roll(df, shift)
 
 
-def wrap_timestamps(df: pd.Series, to_timestamps: list[pd.Timestamp]) -> pd.Series:
+def wrap_timestamps(
+    df: "pd.Series[pd.Timestamp]", to_timestamps: list[pd.Timestamp]
+) -> "pd.Series[pd.Timestamp]":
     """Wrap pandas timeseries so it conforms to a list of timestamps."""
-    arr = np.sort(to_timestamps)
+    arr = np.sort(np.array(to_timestamps))
     freqs = set((np.roll(arr, -1) - arr)[:-1])
     assert len(freqs), f"Timeseries has more than one frequency, {freqs}"
     freq = list(freqs)[0]

--- a/tests/test_checker_representative_time.py
+++ b/tests/test_checker_representative_time.py
@@ -14,7 +14,7 @@ def ingest_data_and_check(
 ) -> None:
     metadata = MetaData()
     with engine.connect() as conn:
-        write_database(df, conn, schema.name, schema.time_config, if_table_exists="replace")
+        write_database(df, conn, schema.name, [schema.time_config], if_table_exists="replace")
         conn.commit()
     metadata.reflect(engine, views=True)
 

--- a/tests/test_mapper_datetime_to_datetime.py
+++ b/tests/test_mapper_datetime_to_datetime.py
@@ -1,0 +1,169 @@
+from zoneinfo import ZoneInfo
+import pytest
+from datetime import datetime, timedelta
+from typing import Any
+import numpy as np
+
+import pandas as pd
+from sqlalchemy import Engine, MetaData
+
+from chronify.sqlalchemy.functions import read_database, write_database
+from chronify.time_series_mapper import map_time
+from chronify.time_configs import DatetimeRange
+from chronify.models import TableSchema
+from chronify.time import TimeIntervalType, MeasurementType
+from chronify.exceptions import ConflictingInputsError, InvalidParameter
+from chronify.datetime_range_generator import DatetimeRangeGenerator
+from chronify.time_utils import shift_time_interval, roll_time_interval, wrap_timestamps
+
+
+def generate_datetime_data(time_config: DatetimeRange) -> pd.Series:
+    return pd.to_datetime(list(DatetimeRangeGenerator(time_config).iter_timestamps()))
+
+
+def generate_datetime_dataframe(schema: TableSchema) -> pd.DataFrame:
+    df = pd.DataFrame({schema.time_config.time_column: generate_datetime_data(schema.time_config)})
+
+    for i, x in enumerate(schema.time_array_id_columns):
+        df[x] = i
+    df[schema.value_column] = np.random.rand(len(df))
+    return df
+
+
+def get_datetime_schema(
+    year: int, tzinfo: ZoneInfo | None, interval_type: TimeIntervalType, name: str
+) -> TableSchema:
+    start = datetime(year=year, month=1, day=1, tzinfo=tzinfo)
+    end = datetime(year=year + 1, month=1, day=1, tzinfo=tzinfo)
+    resolution = timedelta(hours=1)
+    length = (end - start) / resolution + 1
+    schema = TableSchema(
+        name=name,
+        time_config=DatetimeRange(
+            start=start,
+            resolution=resolution,
+            length=length,
+            interval_type=interval_type,
+            time_column="timestamp",
+        ),
+        time_array_id_columns=["id"],
+        value_column="value",
+    )
+    return schema
+
+
+def check_dataframes(
+    dfi: pd.DataFrame, dfo: pd.DataFrame, from_schema: TableSchema, to_schema: TableSchema
+) -> None:
+    assert (
+        dfo[to_schema.time_config.time_column] == dfi[from_schema.time_config.time_column]
+    ).all()
+    match from_schema.time_config.interval_type, to_schema.time_config.interval_type:
+        case TimeIntervalType.PERIOD_BEGINNING, TimeIntervalType.PERIOD_ENDING:
+            shift = 1
+        case TimeIntervalType.PERIOD_ENDING, TimeIntervalType.PERIOD_BEGINNING:
+            shift = -1
+    assert (np.array(dfo["value"]) == np.roll(dfi["value"], shift)).all()
+
+
+def run_test(
+    engine: Engine,
+    df: pd.DataFrame,
+    from_schema: TableSchema,
+    to_schema: TableSchema,
+    error: tuple[Any, str],
+) -> None:
+    # Ingest
+    metadata = MetaData()
+    with engine.connect() as conn:
+        write_database(
+            df, conn, from_schema.name, [from_schema.time_config], if_table_exists="replace"
+        )
+        conn.commit()
+    metadata.reflect(engine, views=True)
+
+    # Map
+    if error:
+        with pytest.raises(error[0], match=error[1]):
+            map_time(engine, metadata, from_schema, to_schema)
+    else:
+        map_time(engine, metadata, from_schema, to_schema)
+
+        # Check mapped table
+        with engine.connect() as conn:
+            query = f"select * from {to_schema.name}"
+            queried = read_database(query, conn, to_schema.time_config)
+        queried = queried.sort_values(by=["id", "timestamp"]).reset_index(drop=True)[df.columns]
+        assert not queried.equals(df)
+        check_dataframes(df, queried, from_schema, to_schema)
+
+
+def test_roll_time_using_shift_and_wrap(iter_engines: Engine) -> None:
+    from_schema = get_datetime_schema(2024, None, TimeIntervalType.PERIOD_ENDING, "from_table")
+    data = generate_datetime_data(from_schema.time_config)
+    df = generate_datetime_dataframe(from_schema)
+    to_schema = get_datetime_schema(2024, None, TimeIntervalType.PERIOD_BEGINNING, "to_table")
+
+    df["rolled"] = roll_time_interval(
+        df[from_schema.time_config.time_column],
+        from_schema.time_config.interval_type,
+        to_schema.time_config.interval_type,
+    )
+    df["rolled2"] = shift_time_interval(
+        df[from_schema.time_config.time_column],
+        from_schema.time_config.interval_type,
+        to_schema.time_config.interval_type,
+    )
+    df["rolled2"] = wrap_timestamps(
+        df["rolled2"],
+        data,
+    )
+    assert df["rolled"].equals(df["rolled2"])
+    assert set(data) == set(df["rolled"].tolist())
+
+
+@pytest.mark.parametrize("tzinfo", [ZoneInfo("US/Eastern"), None])
+def test_time_interval_shift(
+    iter_engines: Engine,
+    tzinfo: ZoneInfo | None,
+) -> None:
+    from_schema = get_datetime_schema(
+        2020, tzinfo, TimeIntervalType.PERIOD_BEGINNING, "from_table"
+    )
+    df = generate_datetime_dataframe(from_schema)
+    to_schema = get_datetime_schema(2020, tzinfo, TimeIntervalType.PERIOD_ENDING, "to_table")
+
+    error = ()
+    run_test(iter_engines, df, from_schema, to_schema, error)
+
+
+def test_instantaneous_interval_type(
+    iter_engines: Engine,
+) -> None:
+    from_schema = get_datetime_schema(2020, None, TimeIntervalType.INSTANTANEOUS, "from_table")
+    df = generate_datetime_dataframe(from_schema)
+    to_schema = get_datetime_schema(2020, None, TimeIntervalType.PERIOD_ENDING, "to_table")
+    error = (InvalidParameter, "Cannot handle")
+    run_test(iter_engines, df, from_schema, to_schema, error)
+
+
+def test_schema_compatibility(
+    iter_engines: Engine,
+) -> None:
+    from_schema = get_datetime_schema(2020, None, TimeIntervalType.PERIOD_BEGINNING, "from_table")
+    df = generate_datetime_dataframe(from_schema)
+    to_schema = get_datetime_schema(2020, None, TimeIntervalType.PERIOD_ENDING, "to_table")
+    to_schema.time_array_id_columns += ["extra_column"]
+    error = (ConflictingInputsError, ".* cannot produce the columns")
+    run_test(iter_engines, df, from_schema, to_schema, error)
+
+
+def test_measurement_type_consistency(
+    iter_engines: Engine,
+) -> None:
+    from_schema = get_datetime_schema(2020, None, TimeIntervalType.PERIOD_BEGINNING, "from_table")
+    df = generate_datetime_dataframe(from_schema)
+    to_schema = get_datetime_schema(2020, None, TimeIntervalType.PERIOD_ENDING, "to_table")
+    to_schema.time_config.measurement_type = MeasurementType.MAX
+    error = (ConflictingInputsError, "Inconsistent measurement_types")
+    run_test(iter_engines, df, from_schema, to_schema, error)

--- a/tests/test_mapper_datetime_to_datetime.py
+++ b/tests/test_mapper_datetime_to_datetime.py
@@ -132,7 +132,6 @@ def test_time_interval_shift(
     )
     df = generate_datetime_dataframe(from_schema)
     to_schema = get_datetime_schema(2020, tzinfo, TimeIntervalType.PERIOD_ENDING, "to_table")
-
     error = ()
     run_test(iter_engines, df, from_schema, to_schema, error)
 

--- a/tests/test_mapper_datetime_to_datetime.py
+++ b/tests/test_mapper_datetime_to_datetime.py
@@ -96,36 +96,49 @@ def get_mapped_results(
 
 
 def check_time_shift_timestamps(
-    dfi: pd.DataFrame, dfo: pd.DataFrame, from_schema: TableSchema, to_schema: TableSchema
+    dfi: pd.DataFrame, dfo: pd.DataFrame, to_time_config: DatetimeRange
 ) -> None:
     assert not dfo.equals(dfi)
-    df_truth = generate_datetime_data(to_schema.time_config)
-    assert (dfo[to_schema.time_config.time_column] == df_truth).all()
+    df_truth = generate_datetime_data(to_time_config)
+    assert (dfo[to_time_config.time_column] == df_truth).all()
 
 
 def check_time_shift_values(
-    dfi: pd.DataFrame, dfo: pd.DataFrame, from_schema: TableSchema, to_schema: TableSchema
+    dfi: pd.DataFrame,
+    dfo: pd.DataFrame,
+    from_time_config: DatetimeRange,
+    to_time_config: DatetimeRange,
 ) -> None:
-    match from_schema.time_config.interval_type, to_schema.time_config.interval_type:
-        case TimeIntervalType.PERIOD_BEGINNING, TimeIntervalType.PERIOD_ENDING:
-            shift = 1
-        case TimeIntervalType.PERIOD_ENDING, TimeIntervalType.PERIOD_BEGINNING:
-            shift = -1
-        case TimeIntervalType.INSTANTANEOUS, TimeIntervalType.INSTANTANEOUS:
-            shift = 0
-    assert (np.array(dfo["value"]) == np.roll(dfi["value"], shift)).all()
+    for idx in [5, 50, 500]:
+        row = dfi.loc[idx]
+        ftz, ttz = from_time_config.start.tzinfo, to_time_config.start.tzinfo
+        if None in (ftz, ttz):
+            ts = row["timestamp"].tz_localize(ttz)
+        else:
+            ts = row["timestamp"].tz_convert(ttz)
+        fint, tint = from_time_config.interval_type, to_time_config.interval_type
+        match fint, tint:
+            case TimeIntervalType.PERIOD_BEGINNING, TimeIntervalType.PERIOD_ENDING:
+                mult = 1
+            case TimeIntervalType.PERIOD_ENDING, TimeIntervalType.PERIOD_BEGINNING:
+                mult = -1
+            case TimeIntervalType.INSTANTANEOUS, TimeIntervalType.INSTANTANEOUS:
+                mult = 0
+        ts += from_time_config.resolution * mult
+        assert row["value"] == dfo.loc[dfo["timestamp"] == ts, "value"].iloc[0]
 
 
 def test_roll_time_using_shift_and_wrap(iter_engines: Engine) -> None:
     from_schema = get_datetime_schema(2024, None, TimeIntervalType.PERIOD_ENDING, "from_table")
-    data = generate_datetime_data(from_schema.time_config)
     df = generate_datetime_dataframe(from_schema)
     to_schema = get_datetime_schema(2024, None, TimeIntervalType.PERIOD_BEGINNING, "to_table")
+    data = generate_datetime_data(to_schema.time_config)
 
     df["rolled"] = roll_time_interval(
         df[from_schema.time_config.time_column],
         from_schema.time_config.interval_type,
         to_schema.time_config.interval_type,
+        data,
     )
     df["rolled2"] = shift_time_interval(
         df[from_schema.time_config.time_column],
@@ -152,19 +165,36 @@ def test_time_interval_shift(
     to_schema = get_datetime_schema(2020, tzinfo, TimeIntervalType.PERIOD_ENDING, "to_table")
 
     queried = get_mapped_results(iter_engines, df, from_schema, to_schema)
-    check_time_shift_timestamps(df, queried, from_schema, to_schema)
-    check_time_shift_values(df, queried, from_schema, to_schema)
+    check_time_shift_timestamps(df, queried, to_schema.time_config)
+    check_time_shift_values(df, queried, from_schema.time_config, to_schema.time_config)
+
+
+@pytest.mark.parametrize("tzinfo", [ZoneInfo("US/Eastern"), None])
+def test_time_interval_shift_different_time_ranges(
+    iter_engines: Engine,
+    tzinfo: ZoneInfo | None,
+) -> None:
+    from_schema = get_datetime_schema(
+        2020, tzinfo, TimeIntervalType.PERIOD_BEGINNING, "from_table"
+    )
+    df = generate_datetime_dataframe(from_schema)
+    to_schema = get_datetime_schema(2020, tzinfo, TimeIntervalType.PERIOD_ENDING, "to_table")
+    to_schema.time_config.start += to_schema.time_config.resolution
+
+    queried = get_mapped_results(iter_engines, df, from_schema, to_schema)
+    check_time_shift_timestamps(df, queried, to_schema.time_config)
+    assert df["value"].equals(queried["value"])
 
 
 @pytest.mark.parametrize(
     "tzinfo_tuple",
     [
-        (ZoneInfo("US/Eastern"), None),
+        # (ZoneInfo("US/Eastern"), None),
         (None, ZoneInfo("EST")),
-        (ZoneInfo("US/Eastern"), ZoneInfo("US/Mountain")),
+        # (ZoneInfo("US/Eastern"), ZoneInfo("US/Mountain")),
     ],
 )
-def test_mapping_different_timezones(
+def test_time_shift_different_timezones(
     iter_engines: Engine, tzinfo_tuple: tuple[ZoneInfo | None]
 ) -> None:
     from_schema = get_datetime_schema(
@@ -176,8 +206,8 @@ def test_mapping_different_timezones(
     )
 
     queried = get_mapped_results(iter_engines, df, from_schema, to_schema)
-    check_time_shift_timestamps(df, queried, from_schema, to_schema)
-    check_time_shift_values(df, queried, from_schema, to_schema)
+    check_time_shift_timestamps(df, queried, to_schema.time_config)
+    check_time_shift_values(df, queried, from_schema.time_config, to_schema.time_config)
 
 
 def test_instantaneous_interval_type(

--- a/tests/test_mapper_representative_time_to_datetime.py
+++ b/tests/test_mapper_representative_time_to_datetime.py
@@ -57,7 +57,7 @@ def run_test(
     metadata = MetaData()
     with engine.connect() as conn:
         write_database(
-            df, conn, from_schema.name, from_schema.time_config, if_table_exists="replace"
+            df, conn, from_schema.name, [from_schema.time_config], if_table_exists="replace"
         )
         conn.commit()
     metadata.reflect(engine, views=True)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,7 +4,7 @@ from sqlalchemy import BigInteger, Boolean, DateTime, Double, Integer, String
 from chronify.models import ColumnDType, _check_name
 
 
-def test_column_dtypes():
+def test_column_dtypes() -> None:
     ColumnDType(name="col1", dtype=Integer())
     for dtype in (BigInteger, Boolean, DateTime, Double, String):
         ColumnDType(name="col1", dtype=dtype())
@@ -16,6 +16,6 @@ def test_column_dtypes():
         ColumnDType(name="col1", dtype="invalid")
 
 
-def test_invalid_column_name():
+def test_invalid_column_name() -> None:
     with pytest.raises(ValueError):
         _check_name(name="invalid - name")

--- a/tests/test_time_series_checker.py
+++ b/tests/test_time_series_checker.py
@@ -78,7 +78,7 @@ def _run_test(
         value_column="value",
     )
     with engine.connect() as conn:
-        write_database(df, conn, schema.name, schema.time_config, if_table_exists="replace")
+        write_database(df, conn, schema.name, [schema.time_config], if_table_exists="replace")
         conn.commit()
     metadata.reflect(engine)
 


### PR DESCRIPTION
Added: 
- shift_time_interval()
- roll_time_interval()
- wrap_timestamps()

All time handling will be done as programmatic mappings.
Refactored common time-mapping functions.
write_database() now takes in more than one time_configs to handling time formatting for sqlite