### PR TITLE
Add support for Hive (Spark) backends

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,9 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11", "3.12"]
-        os: [ubuntu-latest, windows-latest]
+        # TODO: skip spark on Windows
+        #os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v4
@@ -27,10 +29,17 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install ".[dev]"
+        python -m pip install ".[dev,spark]"
+        wget https://dlcdn.apache.org/spark/spark-3.5.4/spark-3.5.4-bin-hadoop3.tgz
+        tar -xzf spark-3.5.4-bin-hadoop3.tgz
+        export SPARK_HOME=$(pwd)/spark-3.5.4-bin-hadoop3
+        export PATH=$SPARK_HOME/sbin:$PATH
+        start-master.sh
+        start-worker.sh spark://$(hostname):7077
+        start-thriftserver.sh --master=spark://$(hostname):7077
     - name: Run pytest with coverage
       run: |
-        pytest -v --cov --cov-report=xml
+        CHRONIFY_HIVE_URL=hive://localhost:10000/default pytest -v --cov --cov-report=xml
     - name: codecov
       uses: codecov/codecov-action@v4.2.0
       if: ${{ matrix.os == env.DEFAULT_OS && matrix.python-version == env.DEFAULT_PYTHON  }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,7 @@ jobs:
         tar -xzf spark-3.5.4-bin-hadoop3.tgz
         export SPARK_HOME=$(pwd)/spark-3.5.4-bin-hadoop3
         export PATH=$SPARK_HOME/sbin:$PATH
-        start-master.sh
-        start-worker.sh spark://$(hostname):7077
-        start-thriftserver.sh --master=spark://$(hostname):7077
+        start-thriftserver.sh
     - name: Run pytest with coverage
       run: |
         CHRONIFY_HIVE_URL=hive://localhost:10000/default pytest -v --cov --cov-report=xml

--- a/docs/how_tos/index.md
+++ b/docs/how_tos/index.md
@@ -11,4 +11,5 @@
     getting_started/index
     ingest_multiple_tables
     map_time_config
+    spark_backend
 ```

--- a/docs/how_tos/spark_backend.md
+++ b/docs/how_tos/spark_backend.md
@@ -1,0 +1,100 @@
+# Apache Spark Backend
+Download Spark from https://spark.apache.org/downloads.html and install it. Spark provides startup
+scripts for UNIX operating systems (not Windows).
+
+## Install chronify with Spark support
+```
+$ pip install chronify[spark]
+```
+
+## Installation on a development computer
+Installation can be as simple as
+```
+$ tar -xzf spark-3.5.4-bin-hadoop3.tgz
+$ export SPARK_HOME=$(pwd)/spark-3.5.4-bin-hadoop3
+```
+
+Start a Thrift server. This allows JDBC clients to send SQL queries to an in-process Spark cluster
+running in local mode.
+```
+$ $SPARK_HOME/sbin/start-thriftserver.sh --master=spark://$(hostname):7077
+```
+
+The URL to connect to this server is `hive://localhost:10000/default`
+
+## Installation on an HPC
+The chronify development team uses these
+[scripts](https://github.com/NREL/HPC/tree/master/applications/spark) to run Spark on NREL's HPC.
+
+## Chronify Usage
+This example creates a chronify Store with Spark as the backend and then adds a view to a Parquet
+file. Chronify will run its normal time checks.
+
+First, create the Parquet file and chronify schema.
+
+```python
+from datetime import datetime, timedelta
+
+import numpy as np
+import pandas as pd
+from chronify import DatetimeRange, Store, TableSchema, CsvTableSchema
+
+initial_time = datetime(2020, 1, 1)
+end_time = datetime(2020, 12, 31, 23)
+resolution = timedelta(hours=1)
+timestamps = pd.date_range(initial_time, end_time, freq=resolution, unit="us")
+dfs = []
+for i in range(1, 4):
+    df = pd.DataFrame(
+        {
+            "timestamp": timestamps,
+            "id": i,
+            "value": np.random.random(len(timestamps)),
+        }
+    )
+    dfs.append(df)
+df = pd.concat(dfs)
+df.to_parquet("data.parquet", index=False)
+schema = TableSchema(
+    name="devices",
+    value_column="value",
+    time_config=DatetimeRange(
+        time_column="timestamp",
+        start=initial_time,
+        length=len(timestamps),
+        resolution=resolution,
+    ),
+    time_array_id_columns=["id"],
+)
+```
+
+```python
+from chronify import Store
+
+store = Store.create_new_hive_store("hive://localhost:10000/default")
+store.create_view_from_parquet()
+```
+
+Verify the data:
+```python
+store.read_table(schema.name).head()
+```
+```
+            timestamp  id     value
+0 2020-01-01 00:00:00   1  0.785399
+1 2020-01-01 01:00:00   1  0.102756
+2 2020-01-01 02:00:00   1  0.178587
+3 2020-01-01 03:00:00   1  0.326194
+4 2020-01-01 04:00:00   1  0.994851
+```
+
+## Time configuration mapping
+The primary use case for Spark is to map datasets that are larger than can be processed by DuckDB
+on one computer. In such a workflow a user would call
+```python
+store.map_table_time_config(src_table_name, dst_schema)
+```
+followed by
+```python
+store.write_table_to_parquet(dst_schema.name, "mapped_data.parquet")
+```

--- a/docs/how_tos/spark_backend.md
+++ b/docs/how_tos/spark_backend.md
@@ -72,7 +72,7 @@ schema = TableSchema(
 from chronify import Store
 
 store = Store.create_new_hive_store("hive://localhost:10000/default")
-store.create_view_from_parquet()
+store.create_view_from_parquet("data.parquet")
 ```
 
 Verify the data:
@@ -92,9 +92,5 @@ store.read_table(schema.name).head()
 The primary use case for Spark is to map datasets that are larger than can be processed by DuckDB
 on one computer. In such a workflow a user would call
 ```python
-store.map_table_time_config(src_table_name, dst_schema)
-```
-followed by
-```python
-store.write_table_to_parquet(dst_schema.name, "mapped_data.parquet")
+store.map_table_time_config(src_table_name, dst_schema, output_file="mapped_data.parquet")
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,26 @@ Python-based modeling packages.
     explanation/index
 ```
 
+## Supported Backends
+While chronify should work with any database supported by SQLAlchemy, it has been tested with
+the following:
+
+- DuckDB (default)
+- SQLite
+- Apache Spark through Apache Thrift Server
+
+DuckDB and SQLite are fully supported.
+
+Because of limitations in the backend software, chronify functionality with Spark is limited to
+the following:
+
+- Create a view into an existing Parquet file (or directory).
+- Perform time series checks.
+- Map between time configurations.
+- Write output data to Parquet files.
+
+There is no support for creating tables and ingesting data with Spark.
+
 ## How to use this guide
 - Refer to [How Tos](#how-tos-page) for step-by-step instructions for creating store and ingesting data.
 - Refer to [Tutorials](#tutorials-page) examples of ingesting different types of data and mapping

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
     "duckdb_engine",
     "loguru",
     "pandas >= 2.2, < 3",
-    "polars ~= 1.11.0",
     "pyarrow",
     "pydantic >= 2.7, < 3",
     "pytz",
@@ -39,6 +38,12 @@ dependencies = [
     "tzdata",
 ]
 [project.optional-dependencies]
+spark = [
+    "pyhive @ git+https://github.com/apache/kyuubi.git#egg=pyhive&subdirectory=python",
+    "thrift",
+    "thrift_sasl",
+]
+
 dev = [
     "mypy",
     "pandas-stubs",
@@ -53,7 +58,6 @@ dev = [
     "autodoc_pydantic~=2.0",
     "sphinx-copybutton",
     "sphinx-tabs~=3.4",
-
 ]
 
 [project.urls]
@@ -119,3 +123,6 @@ docstring-code-line-length = "dynamic"
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["E402", "F401"]
 "**/{tests,docs,tools}/*" = ["E402"]
+
+[tool.hatch]
+metadata.allow-direct-references = true

--- a/src/chronify/__init__.py
+++ b/src/chronify/__init__.py
@@ -1,18 +1,53 @@
 import importlib.metadata as metadata
 
-from chronify.store import Store
+from chronify.exceptions import (
+    ChronifyExceptionBase,
+    ConflictingInputsError,
+    InvalidTable,
+    InvalidOperation,
+    InvalidParameter,
+    MissingParameter,
+    TableAlreadyExists,
+    TableNotStored,
+)
 from chronify.models import (
     ColumnDType,
     CsvTableSchema,
     PivotedTableSchema,
     TableSchema,
 )
+from chronify.store import Store
 from chronify.time import RepresentativePeriodFormat
 from chronify.time_configs import (
     AnnualTimeRange,
     DatetimeRange,
     IndexTimeRange,
     RepresentativePeriodTime,
+    TimeBaseModel,
+    TimeBasedDataAdjustment,
+)
+
+__all__ = (
+    "AnnualTimeRange",
+    "ChronifyExceptionBase",
+    "ColumnDType",
+    "ConflictingInputsError",
+    "CsvTableSchema",
+    "DatetimeRange",
+    "IndexTimeRange",
+    "InvalidOperation",
+    "InvalidParameter",
+    "InvalidTable",
+    "MissingParameter",
+    "PivotedTableSchema",
+    "RepresentativePeriodFormat",
+    "RepresentativePeriodTime",
+    "Store",
+    "TableAlreadyExists",
+    "TableNotStored",
+    "TableSchema",
+    "TimeBaseModel",
+    "TimeBasedDataAdjustment",
 )
 
 __version__ = metadata.metadata("chronify")["Version"]

--- a/src/chronify/duckdb/functions.py
+++ b/src/chronify/duckdb/functions.py
@@ -1,6 +1,5 @@
 from collections.abc import Iterable
 from datetime import datetime, timedelta
-from pathlib import Path
 
 import duckdb
 from duckdb import DuckDBPyRelation
@@ -28,17 +27,6 @@ def add_datetime_column(
     #    FROM rel
     #    """
     # )
-
-
-def make_write_parquet_query(table_or_view: str, file_path: Path | str) -> str:
-    """Make an SQL string that can be used to write a Parquet file from a table or view."""
-    # TODO: Hive partitioning?
-    return f"""
-        COPY
-            (SELECT * FROM {table_or_view})
-            TO '{file_path}'
-            (FORMAT 'parquet');
-        """
 
 
 def unpivot(

--- a/src/chronify/hive_functions.py
+++ b/src/chronify/hive_functions.py
@@ -1,0 +1,35 @@
+import atexit
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Optional
+
+from sqlalchemy import Engine, MetaData, text
+
+from chronify.utils.path_utils import delete_if_exists
+
+
+def create_materialized_view(
+    query: str,
+    dst_table: str,
+    engine: Engine,
+    metadata: MetaData,
+    scratch_dir: Optional[Path] = None,
+) -> None:
+    """Create a materialized view with a Parquet file. This is a workaround for an undiagnosed
+    problem with timestamps and time zones with hive.
+    """
+    with NamedTemporaryFile(dir=scratch_dir, suffix=".parquet") as f:
+        f.close()
+        output = Path(f.name)
+    write_query = f"""
+        INSERT OVERWRITE DIRECTORY
+            '{output}'
+            USING parquet
+            ({query})
+    """
+    with engine.begin() as conn:
+        conn.execute(text(write_query))
+        atexit.register(lambda: delete_if_exists(output))
+        view_query = f"CREATE VIEW {dst_table} AS SELECT * FROM parquet.`{output}`"
+        conn.execute(text(view_query))
+    metadata.reflect(engine, views=True)

--- a/src/chronify/models.py
+++ b/src/chronify/models.py
@@ -5,7 +5,7 @@ import duckdb.typing
 import pandas as pd
 from duckdb.typing import DuckDBPyType
 from pydantic import Field, field_validator, model_validator
-from sqlalchemy import BigInteger, Boolean, DateTime, Double, Integer, String
+from sqlalchemy import BigInteger, Boolean, DateTime, Double, Float, Integer, SmallInteger, String
 from typing_extensions import Annotated
 
 from chronify.base_models import ChronifyBaseModel
@@ -164,7 +164,9 @@ _DUCKDB_TYPES_TO_SQLALCHEMY_TYPES = {
     duckdb.typing.BIGINT.id: BigInteger,  # type: ignore
     duckdb.typing.BOOLEAN.id: Boolean,  # type: ignore
     duckdb.typing.DOUBLE.id: Double,  # type: ignore
+    duckdb.typing.FLOAT.id: Float,  # type: ignore
     duckdb.typing.INTEGER.id: Integer,  # type: ignore
+    duckdb.typing.TINYINT.id: SmallInteger,  # type: ignore
     duckdb.typing.VARCHAR.id: String,  # type: ignore
     # Note: timestamp requires special handling because of timezone in sqlalchemy.
 }

--- a/src/chronify/models.py
+++ b/src/chronify/models.py
@@ -29,10 +29,6 @@ class TableSchemaBase(ChronifyBaseModel):
             "Should not include time columns."
         ),
     ]
-    ignore_columns: list[str] = Field(
-        default=[],
-        description="Columns in the table to ignore",
-    )
 
     @field_validator("time_config")
     @classmethod

--- a/src/chronify/models.py
+++ b/src/chronify/models.py
@@ -253,24 +253,16 @@ class ColumnDType(ChronifyBaseModel):
 class CsvTableSchema(TableSchemaBase):
     """Defines the schema of data in a CSV file."""
 
-    pivoted_dimension_name: Annotated[
-        Optional[str],
-        Field(
-            default=None,
-            description="Only set if the table is pivoted. Use this name for the column "
-            "representing that dimension when unpivoting.",
-        ),
-    ]
-    column_dtypes: Annotated[
-        Optional[list[ColumnDType]],
-        Field(
-            default=None,
-            description="Column types. Will try to infer types of any column not listed.",
-        ),
-    ]
-    value_columns: Annotated[
-        list[str], Field(description="Columns in the table that contain values.")
-    ]
+    pivoted_dimension_name: Optional[str] = Field(
+        default=None,
+        description="Only set if the table is pivoted. Use this name for the column "
+        "representing that dimension when unpivoting.",
+    )
+    column_dtypes: Optional[list[ColumnDType]] = Field(
+        default=None,
+        description="Column types. Will try to infer types of any column not listed.",
+    )
+    value_columns: list[str] = Field(description="Columns in the table that contain values.")
     time_array_id_columns: list[str] = Field(
         default=[],
         description="Columns in the table that uniquely identify time arrays. "

--- a/src/chronify/models.py
+++ b/src/chronify/models.py
@@ -29,6 +29,10 @@ class TableSchemaBase(ChronifyBaseModel):
             "Should not include time columns."
         ),
     ]
+    ignore_columns: list[str] = Field(
+        default=[],
+        description="Columns in the table to ignore",
+    )
 
     @field_validator("time_config")
     @classmethod

--- a/src/chronify/schema_manager.py
+++ b/src/chronify/schema_manager.py
@@ -1,4 +1,5 @@
 import json
+from typing import Optional
 
 from loguru import logger
 from sqlalchemy import (
@@ -11,6 +12,7 @@ from sqlalchemy import (
     delete,
     insert,
     select,
+    text,
 )
 
 from chronify.exceptions import (
@@ -29,40 +31,58 @@ class SchemaManager:
     def __init__(self, engine: Engine, metadata: MetaData):
         self._engine = engine
         self._metadata = metadata
+        # Caching is not necessary if using SQLite, which provides very fast performance (~1 us)
+        # for checking schemas in the **tiny** schemas table.
+        # The same lookups in DuckDB are taking over 100 us.
         self._cache: dict[str, TableSchema] = {}
 
         if self.SCHEMAS_TABLE in self._metadata.tables:
             logger.info("Loaded existing database {}", self._engine.url.database)
             self.rebuild_cache()
         else:
-            table = Table(
-                self.SCHEMAS_TABLE,
-                self._metadata,
-                Column("name", String),
-                Column("schema", String),  # schema encoded as JSON
-            )
-            # TODO: will this work for Spark? Needs to be mutable.
-            self._metadata.create_all(self._engine, tables=[table])
+            if self._engine.name == "hive":
+                # metadata.create_all doesn't work here.
+                with self._engine.begin() as conn:
+                    conn.execute(text(f"DROP TABLE IF EXISTS {self.SCHEMAS_TABLE}"))
+                    conn.execute(
+                        text(f"CREATE TABLE {self.SCHEMAS_TABLE}(name STRING, schema STRING)")
+                    )
+                self._metadata.reflect(self._engine)
+            else:
+                table = Table(
+                    self.SCHEMAS_TABLE,
+                    self._metadata,
+                    Column("name", String),
+                    Column("schema", String),  # schema encoded as JSON
+                )
+                self._metadata.create_all(self._engine, tables=[table])
             logger.info("Initialized new database: {}", self._engine.url.database)
 
     def _get_schema_table(self) -> Table:
-        return Table(self.SCHEMAS_TABLE, self._metadata)
+        return (
+            self._metadata.tables[self.SCHEMAS_TABLE]
+            if self._engine.name == "hive"
+            else Table(self.SCHEMAS_TABLE, self._metadata)
+        )
 
     def add_schema(self, conn: Connection, schema: TableSchema) -> Table:
         """Add the schema to the store."""
         table = self._get_schema_table()
         stmt = insert(table).values(name=schema.name, schema=schema.model_dump_json())
         conn.execute(stmt)
-        logger.debug("Added schema for table {}", schema.name)
-        # Note: Don't add to the schema cache here. That should only happen after a
-        # database commit.
+        # If there is a rollback after this addition to cached, things _should_ still be OK.
+        # The table will be deleted and any attempted reads will fail with an error.
+        # There will be a stale entry in cache, but it will be overwritten if the user ever
+        # adds a new table with the same name.
+        self._cache[schema.name] = schema
+        logger.trace("Added schema for table {}", schema.name)
         return table
 
-    def get_schema(self, name: str) -> TableSchema:
+    def get_schema(self, name: str, conn: Optional[Connection] = None) -> TableSchema:
         """Retrieve the schema for the table with name."""
         schema = self._cache.get(name)
         if schema is None:
-            self.rebuild_cache()
+            self.rebuild_cache(conn=conn)
 
         schema = self._cache.get(name)
         if schema is None:
@@ -72,23 +92,36 @@ class SchemaManager:
         return self._cache[name]
 
     def remove_schema(self, conn: Connection, name: str) -> None:
+        """Remove the schema from the store."""
         table = self._get_schema_table()
-        stmt = delete(table).where(table.c["name"] == name)
-        conn.execute(stmt)
+        if self._engine.name == "hive":
+            pass
+            # TODO: This is not working because pandas can't find the table.
+            # stmt = select(table).where(table.c.name != name)
+            # df = pd.read_sql_query(stmt, conn)
+            # conn.execute(text(f"DROP TABLE {self.SCHEMAS_TABLE}"))
+            # df.to_sql(self.SCHEMAS_TABLE, conn)
+        else:
+            stmt = delete(table).where(table.c["name"] == name)
+            conn.execute(stmt)
 
-    def rebuild_cache(self) -> None:
+        self._cache.pop(name)
+
+    def rebuild_cache(self, conn: Optional[Connection] = None) -> None:
         """Rebuild the cache of schemas."""
         self._cache.clear()
-        table = self._get_schema_table()
-        with self._engine.connect() as conn:
-            stmt = select(table)
-            res = conn.execute(stmt).fetchall()
-            for name, text in res:
-                schema = TableSchema(**json.loads(text))
-                assert name == schema.name
-                assert name not in self._cache
-                self._cache[name] = schema
+        if conn is None:
+            with self._engine.connect() as conn:
+                self._rebuild_cache(conn)
+        else:
+            self._rebuild_cache(conn)
 
-    def update_cache(self, schema: TableSchema) -> None:
-        # Allow overwrites.
-        self._cache[schema.name] = schema
+    def _rebuild_cache(self, conn: Connection) -> None:
+        table = self._get_schema_table()
+        stmt = select(table)
+        res = conn.execute(stmt).fetchall()
+        for name, json_text in res:
+            schema = TableSchema(**json.loads(json_text))
+            assert name == schema.name
+            assert name not in self._cache
+            self._cache[name] = schema

--- a/src/chronify/sqlalchemy/functions.py
+++ b/src/chronify/sqlalchemy/functions.py
@@ -144,8 +144,8 @@ def _write_to_hive(
     for config in configs:
         if isinstance(config, DatetimeRange):
             if isinstance(df2[config.time_column].dtype, DatetimeTZDtype):
-                # Spark doesn't like ns.
-                # TODO: is there a better way to change from ns to us?
+                # Spark doesn't like ns. That might change in the future.
+                # Pandas might offer a better way to change from ns to us in the future.
                 new_dtype = df2[config.time_column].dtype.name.replace(
                     "datetime64[ns", "datetime64[us"
                 )
@@ -169,6 +169,7 @@ def _write_to_hive(
             conn.execute(text(f"DROP VIEW IF EXISTS {table_name}"))
             query = f"CREATE VIEW {table_name} AS {select_stmt}"
         case "fail":
+            # Let the database fail the operation if the table already exists.
             query = f"CREATE VIEW {table_name} AS {select_stmt}"
         case _:
             msg = f"{if_table_exists=}"

--- a/src/chronify/sqlalchemy/functions.py
+++ b/src/chronify/sqlalchemy/functions.py
@@ -53,6 +53,10 @@ def write_database(
 ) -> None:
     """Write a Pandas DataFrame to the database.
     configs allows sqlite formatting for more than one datetime columns.
+
+    Note: Writing persistent data with Hive as the backend is not supported.
+    This function will write the dataframe to a temporary Parquet file and then create
+    a view into that file. This is only to support ephemeral tables, such as for mapping tables.
     """
     match conn.engine.name:
         case "duckdb":

--- a/src/chronify/time_series_checker.py
+++ b/src/chronify/time_series_checker.py
@@ -105,7 +105,7 @@ class TimeSeriesChecker:
                 msg = (
                     f"The count of time values in each time array must be {count}, and each "
                     "value must be distinct. "
-                    f"Time array identifiers: {values}."
+                    f"Time array identifiers: {values}. "
                     f"count = {count_by_ta}, distinct count = {distinct_count_by_ta}. "
                 )
                 raise InvalidTable(msg)

--- a/src/chronify/time_series_mapper.py
+++ b/src/chronify/time_series_mapper.py
@@ -15,6 +15,8 @@ def map_time(
     from_schema: TableSchema,
     to_schema: TableSchema,
     scratch_dir: Optional[Path] = None,
+    output_file: Optional[Path] = None,
+    check_mapped_timestamps: bool = True,
 ) -> None:
     """Function to map time using the appropriate TimeSeriesMapper model."""
 
@@ -22,13 +24,17 @@ def map_time(
         to_schema.time_config, DatetimeRange
     ):
         MapperRepresentativeTimeToDatetime(engine, metadata, from_schema, to_schema).map_time(
-            scratch_dir=scratch_dir
+            scratch_dir=scratch_dir,
+            output_file=output_file,
+            check_mapped_timestamps=check_mapped_timestamps,
         )
     elif isinstance(from_schema.time_config, DatetimeRange) and isinstance(
         to_schema.time_config, DatetimeRange
     ):
         MapperDatetimeToDatetime(engine, metadata, from_schema, to_schema).map_time(
-            scratch_dir=scratch_dir
+            scratch_dir=scratch_dir,
+            output_file=output_file,
+            check_mapped_timestamps=check_mapped_timestamps,
         )
     else:
         msg = f"No mapping function for {from_schema.time_config.__class__=} >> {to_schema.time_config.__class__=}"

--- a/src/chronify/time_series_mapper.py
+++ b/src/chronify/time_series_mapper.py
@@ -16,7 +16,7 @@ def map_time(
     to_schema: TableSchema,
     scratch_dir: Optional[Path] = None,
     output_file: Optional[Path] = None,
-    check_mapped_timestamps: bool = True,
+    check_mapped_timestamps: bool = False,
 ) -> None:
     """Function to map time using the appropriate TimeSeriesMapper model."""
 

--- a/src/chronify/time_series_mapper.py
+++ b/src/chronify/time_series_mapper.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+from typing import Optional
+
 from sqlalchemy import Engine, MetaData
 from chronify.models import TableSchema
 
@@ -7,18 +10,26 @@ from chronify.time_configs import RepresentativePeriodTime, DatetimeRange
 
 
 def map_time(
-    engine: Engine, metadata: MetaData, from_schema: TableSchema, to_schema: TableSchema
+    engine: Engine,
+    metadata: MetaData,
+    from_schema: TableSchema,
+    to_schema: TableSchema,
+    scratch_dir: Optional[Path] = None,
 ) -> None:
     """Function to map time using the appropriate TimeSeriesMapper model."""
 
     if isinstance(from_schema.time_config, RepresentativePeriodTime) and isinstance(
         to_schema.time_config, DatetimeRange
     ):
-        MapperRepresentativeTimeToDatetime(engine, metadata, from_schema, to_schema).map_time()
+        MapperRepresentativeTimeToDatetime(engine, metadata, from_schema, to_schema).map_time(
+            scratch_dir=scratch_dir
+        )
     elif isinstance(from_schema.time_config, DatetimeRange) and isinstance(
         to_schema.time_config, DatetimeRange
     ):
-        MapperDatetimeToDatetime(engine, metadata, from_schema, to_schema).map_time()
+        MapperDatetimeToDatetime(engine, metadata, from_schema, to_schema).map_time(
+            scratch_dir=scratch_dir
+        )
     else:
         msg = f"No mapping function for {from_schema.time_config.__class__=} >> {to_schema.time_config.__class__=}"
         raise NotImplementedError(msg)

--- a/src/chronify/time_series_mapper_base.py
+++ b/src/chronify/time_series_mapper_base.py
@@ -9,9 +9,15 @@ from loguru import logger
 from sqlalchemy import Engine, MetaData, Table, select, text
 from chronify.hive_functions import create_materialized_view
 
-from chronify.sqlalchemy.functions import write_database
+from chronify.sqlalchemy.functions import (
+    create_view_from_parquet,
+    write_database,
+    write_query_to_parquet,
+)
 from chronify.models import TableSchema, MappingTableSchema
-from chronify.exceptions import TableAlreadyExists, ConflictingInputsError
+from chronify.exceptions import (
+    ConflictingInputsError,
+)
 from chronify.utils.sqlalchemy_table import create_table
 from chronify.time_series_checker import check_timestamps
 from chronify.time import TimeIntervalType
@@ -21,7 +27,11 @@ class TimeSeriesMapperBase(abc.ABC):
     """Maps time series data from one configuration to another."""
 
     def __init__(
-        self, engine: Engine, metadata: MetaData, from_schema: TableSchema, to_schema: TableSchema
+        self,
+        engine: Engine,
+        metadata: MetaData,
+        from_schema: TableSchema,
+        to_schema: TableSchema,
     ) -> None:
         self._engine = engine
         self._metadata = metadata
@@ -75,41 +85,60 @@ def apply_mapping(
     engine: Engine,
     metadata: MetaData,
     scratch_dir: Optional[Path] = None,
+    output_file: Optional[Path] = None,
+    check_mapped_timestamps: bool = True,
 ) -> None:
     """
     Apply mapping to create result table with process to clean up and roll back if checks fail
     """
-    if mapping_schema.name in metadata.tables:
-        msg = (
-            f"table {mapping_schema.name} already exists, delete it or use a different table name."
+    with engine.begin() as conn:
+        write_database(
+            df_mapping,
+            conn,
+            mapping_schema.name,
+            mapping_schema.time_configs,
+            if_table_exists="fail",
         )
-        raise TableAlreadyExists(msg)
+    metadata.reflect(engine, views=True)
 
+    created_tmp_view = False
     try:
-        with engine.begin() as conn:
-            write_database(
-                df_mapping,
-                conn,
-                mapping_schema.name,
-                mapping_schema.time_configs,
-                if_table_exists="fail",
-            )
-
-        metadata.reflect(engine, views=True)
-        _apply_mapping(mapping_schema.name, from_schema, to_schema, engine, metadata, scratch_dir)
-        mapped_table = Table(to_schema.name, metadata)
-        try:
+        _apply_mapping(
+            mapping_schema.name,
+            from_schema,
+            to_schema,
+            engine,
+            metadata,
+            scratch_dir,
+            output_file,
+        )
+        created_tmp_view = _create_view_if_necessary(
+            engine, metadata, to_schema.name, check_mapped_timestamps, output_file
+        )
+        if check_mapped_timestamps:
+            mapped_table = Table(to_schema.name, metadata)
             with engine.connect() as conn:
-                check_timestamps(conn, mapped_table, to_schema)
-        except Exception:
-            logger.exception("check_timestamps failed on mapped table {}. Drop it", to_schema.name)
-            raise
+                try:
+                    check_timestamps(conn, mapped_table, to_schema)
+                except Exception:
+                    logger.exception(
+                        "check_timestamps failed on mapped table {}. Drop it",
+                        to_schema.name,
+                    )
+                    if output_file is None:
+                        conn.execute(text(f"DROP TABLE {to_schema.name}"))
+                    raise
     finally:
-        if mapping_schema.name in metadata.tables:
-            with engine.begin() as conn:
-                table_type = "view" if engine.name == "hive" else "table"
-                conn.execute(text(f"DROP {table_type} {mapping_schema.name}"))
-            metadata.remove(Table(mapping_schema.name, metadata))
+        with engine.begin() as conn:
+            table_type = "view" if engine.name == "hive" else "table"
+            conn.execute(text(f"DROP {table_type} IF EXISTS {mapping_schema.name}"))
+
+            if created_tmp_view:
+                conn.execute(text(f"DROP VIEW IF EXISTS {to_schema.name}"))
+                metadata.remove(Table(to_schema.name, metadata))
+
+        metadata.remove(Table(mapping_schema.name, metadata))
+        metadata.reflect(engine, views=True)
 
 
 def _apply_mapping(
@@ -119,10 +148,15 @@ def _apply_mapping(
     engine: Engine,
     metadata: MetaData,
     scratch_dir: Optional[Path] = None,
+    output_file: Optional[Path] = None,
 ) -> None:
     """Apply mapping to create result as a table according to_schema
     - Columns used to join the from_table are prefixed with "from_" in the mapping table
     """
+    # if output_file is not None and engine.name != "hive":
+    # msg = f"A mapping can only be written to Parquet if the engine is hive: {engine.name=}"
+    # raise InvalidOperation(msg)
+
     left_table = Table(from_schema.name, metadata)
     right_table = Table(mapping_table_name, metadata)
     left_table_columns = [x.name for x in left_table.columns]
@@ -143,9 +177,30 @@ def _apply_mapping(
 
     on_stmt = reduce(and_, (left_table.c[x] == right_table.c["from_" + x] for x in keys))
     query = select(*select_stmt).select_from(left_table).join(right_table, on_stmt)
+
+    if output_file is not None:
+        write_query_to_parquet(engine, str(query), output_file, overwrite=True)
+        return
+
     if engine.name == "hive":
         create_materialized_view(
             str(query), to_schema.name, engine, metadata, scratch_dir=scratch_dir
         )
     else:
         create_table(to_schema.name, query, engine, metadata)
+
+
+def _create_view_if_necessary(
+    engine: Engine,
+    metadata: MetaData,
+    name: str,
+    check_mapped_timestamps: bool,
+    output_file: Optional[Path],
+) -> bool:
+    if check_mapped_timestamps:
+        if output_file is not None:
+            with engine.begin() as conn:
+                create_view_from_parquet(conn, name, output_file)
+            metadata.reflect(engine, views=True)
+            return True
+    return False

--- a/src/chronify/time_series_mapper_base.py
+++ b/src/chronify/time_series_mapper_base.py
@@ -153,10 +153,6 @@ def _apply_mapping(
     """Apply mapping to create result as a table according to_schema
     - Columns used to join the from_table are prefixed with "from_" in the mapping table
     """
-    # if output_file is not None and engine.name != "hive":
-    # msg = f"A mapping can only be written to Parquet if the engine is hive: {engine.name=}"
-    # raise InvalidOperation(msg)
-
     left_table = Table(from_schema.name, metadata)
     right_table = Table(mapping_table_name, metadata)
     left_table_columns = [x.name for x in left_table.columns]

--- a/src/chronify/time_series_mapper_datetime.py
+++ b/src/chronify/time_series_mapper_datetime.py
@@ -52,7 +52,12 @@ class MapperDatetimeToDatetime(TimeSeriesMapperBase):
             msg = f"DatetimeRange length must match between from_schema and to_schema. {flen} vs. {tlen}"
             raise ConflictingInputsError(msg)
 
-    def map_time(self, scratch_dir: Optional[Path] = None) -> None:
+    def map_time(
+        self,
+        scratch_dir: Optional[Path] = None,
+        output_file: Optional[Path] = None,
+        check_mapped_timestamps: bool = True,
+    ) -> None:
         """Convert time columns with from_schema to to_schema configuration."""
         self.check_schema_consistency()
         df, mapping_schema = self._create_mapping()
@@ -64,6 +69,8 @@ class MapperDatetimeToDatetime(TimeSeriesMapperBase):
             self._engine,
             self._metadata,
             scratch_dir=scratch_dir,
+            output_file=output_file,
+            check_mapped_timestamps=check_mapped_timestamps,
         )
         # TODO - add handling for changing resolution - Issue #30
 

--- a/src/chronify/time_series_mapper_datetime.py
+++ b/src/chronify/time_series_mapper_datetime.py
@@ -56,7 +56,7 @@ class MapperDatetimeToDatetime(TimeSeriesMapperBase):
         self,
         scratch_dir: Optional[Path] = None,
         output_file: Optional[Path] = None,
-        check_mapped_timestamps: bool = True,
+        check_mapped_timestamps: bool = False,
     ) -> None:
         """Convert time columns with from_schema to to_schema configuration."""
         self.check_schema_consistency()

--- a/src/chronify/time_series_mapper_datetime.py
+++ b/src/chronify/time_series_mapper_datetime.py
@@ -1,4 +1,6 @@
 import logging
+from pathlib import Path
+from typing import Optional
 
 import pandas as pd
 from sqlalchemy import Engine, MetaData
@@ -50,12 +52,18 @@ class MapperDatetimeToDatetime(TimeSeriesMapperBase):
             msg = f"DatetimeRange length must match between from_schema and to_schema. {flen} vs. {tlen}"
             raise ConflictingInputsError(msg)
 
-    def map_time(self) -> None:
+    def map_time(self, scratch_dir: Optional[Path] = None) -> None:
         """Convert time columns with from_schema to to_schema configuration."""
         self.check_schema_consistency()
         df, mapping_schema = self._create_mapping()
         apply_mapping(
-            df, mapping_schema, self._from_schema, self._to_schema, self._engine, self._metadata
+            df,
+            mapping_schema,
+            self._from_schema,
+            self._to_schema,
+            self._engine,
+            self._metadata,
+            scratch_dir=scratch_dir,
         )
         # TODO - add handling for changing resolution - Issue #30
 

--- a/src/chronify/time_series_mapper_representative.py
+++ b/src/chronify/time_series_mapper_representative.py
@@ -47,7 +47,12 @@ class MapperRepresentativeTimeToDatetime(TimeSeriesMapperBase):
             msg = f"time_zone is required for tz-aware representative time mapping and it is missing from source table: {self._from_schema.name}"
             raise MissingParameter(msg)
 
-    def map_time(self, scratch_dir: Optional[Path] = None) -> None:
+    def map_time(
+        self,
+        scratch_dir: Optional[Path] = None,
+        output_file: Optional[Path] = None,
+        check_mapped_timestamps: bool = True,
+    ) -> None:
         """Convert time columns with from_schema to to_schema configuration."""
         is_tz_naive = self._to_time_config.is_time_zone_naive()
         self.check_schema_consistency()
@@ -63,6 +68,8 @@ class MapperRepresentativeTimeToDatetime(TimeSeriesMapperBase):
             self._engine,
             self._metadata,
             scratch_dir=scratch_dir,
+            output_file=output_file,
+            check_mapped_timestamps=check_mapped_timestamps,
         )
 
     def _create_mapping(self, is_tz_naive: bool) -> tuple[pd.DataFrame, MappingTableSchema]:

--- a/src/chronify/time_series_mapper_representative.py
+++ b/src/chronify/time_series_mapper_representative.py
@@ -1,4 +1,6 @@
 import logging
+from pathlib import Path
+from typing import Optional
 
 import pandas as pd
 from sqlalchemy import Engine, MetaData, Table, select
@@ -45,7 +47,7 @@ class MapperRepresentativeTimeToDatetime(TimeSeriesMapperBase):
             msg = f"time_zone is required for tz-aware representative time mapping and it is missing from source table: {self._from_schema.name}"
             raise MissingParameter(msg)
 
-    def map_time(self) -> None:
+    def map_time(self, scratch_dir: Optional[Path] = None) -> None:
         """Convert time columns with from_schema to to_schema configuration."""
         is_tz_naive = self._to_time_config.is_time_zone_naive()
         self.check_schema_consistency()
@@ -54,7 +56,13 @@ class MapperRepresentativeTimeToDatetime(TimeSeriesMapperBase):
 
         df, mapping_schema = self._create_mapping(is_tz_naive)
         apply_mapping(
-            df, mapping_schema, self._from_schema, self._to_schema, self._engine, self._metadata
+            df,
+            mapping_schema,
+            self._from_schema,
+            self._to_schema,
+            self._engine,
+            self._metadata,
+            scratch_dir=scratch_dir,
         )
 
     def _create_mapping(self, is_tz_naive: bool) -> tuple[pd.DataFrame, MappingTableSchema]:
@@ -98,6 +106,10 @@ class MapperRepresentativeTimeToDatetime(TimeSeriesMapperBase):
             from_columns.append("time_zone")
 
         df = df.rename(columns={x: "from_" + x for x in from_columns})
+
+        if time_col != to_time_col:
+            # TODO: confirm with Lixi. Seems like it was accidental to leave this column.
+            df.drop(time_col, axis=1, inplace=True)
 
         mapping_schema = MappingTableSchema(
             name="mapping_table",

--- a/src/chronify/time_series_mapper_representative.py
+++ b/src/chronify/time_series_mapper_representative.py
@@ -51,7 +51,7 @@ class MapperRepresentativeTimeToDatetime(TimeSeriesMapperBase):
         self,
         scratch_dir: Optional[Path] = None,
         output_file: Optional[Path] = None,
-        check_mapped_timestamps: bool = True,
+        check_mapped_timestamps: bool = False,
     ) -> None:
         """Convert time columns with from_schema to to_schema configuration."""
         is_tz_naive = self._to_time_config.is_time_zone_naive()
@@ -115,7 +115,6 @@ class MapperRepresentativeTimeToDatetime(TimeSeriesMapperBase):
         df = df.rename(columns={x: "from_" + x for x in from_columns})
 
         if time_col != to_time_col:
-            # TODO: confirm with Lixi. Seems like it was accidental to leave this column.
             df.drop(time_col, axis=1, inplace=True)
 
         mapping_schema = MappingTableSchema(

--- a/src/chronify/utils/path_utils.py
+++ b/src/chronify/utils/path_utils.py
@@ -1,0 +1,34 @@
+import shutil
+
+from pathlib import Path
+
+from chronify.exceptions import InvalidOperation
+
+
+def check_overwrite(path: Path, overwrite: bool) -> None:
+    """Check if the path exists, handling the user flag overwrite."""
+    if not path.exists():
+        return
+
+    if overwrite:
+        if path.is_dir():
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+    else:
+        msg = f"{path=} already exists. Choose a different path or set overwrite=True."
+        raise InvalidOperation(msg)
+
+
+def delete_if_exists(path: Path) -> None:
+    """Delete the path if it exists, handling files and directories."""
+    if path.exists():
+        if path.is_dir():
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+
+
+def to_path(path: Path | str) -> Path:
+    """Convert the instance to a Path if is not already one."""
+    return path if isinstance(path, Path) else Path(path)

--- a/src/chronify/utils/path_utils.py
+++ b/src/chronify/utils/path_utils.py
@@ -30,5 +30,8 @@ def delete_if_exists(path: Path) -> None:
 
 
 def to_path(path: Path | str) -> Path:
-    """Convert the instance to a Path if is not already one."""
+    """Convert the instance to a Path if is not already one.
+    This is here because calling Path on an object that already a Path does a bunch of work.
+    This is significantly faster in relative scale (but still only ~1 us).
+    """
     return path if isinstance(path, Path) else Path(path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any, Generator
 
 import numpy as np
@@ -5,6 +6,7 @@ import pandas as pd
 import pytest
 from sqlalchemy import Engine, create_engine
 from chronify.models import TableSchema
+from chronify.store import Store
 from chronify.time import RepresentativePeriodFormat
 
 from chronify.time_configs import RepresentativePeriodTime
@@ -14,6 +16,9 @@ ENGINES: dict[str, dict[str, Any]] = {
     "duckdb": {"url": "duckdb:///:memory:", "connect_args": {}, "kwargs": {}},
     "sqlite": {"url": "sqlite:///:memory:", "connect_args": {}, "kwargs": {}},
 }
+HIVE_URL = os.getenv("CHRONIFY_HIVE_URL")
+if HIVE_URL is not None:
+    ENGINES["hive"] = {"url": HIVE_URL, "connect_args": {}, "kwargs": {}}
 
 
 @pytest.fixture
@@ -22,14 +27,39 @@ def create_duckdb_engine() -> Engine:
     return create_engine("duckdb:///:memory:")
 
 
-@pytest.fixture(params=ENGINES.keys())
+@pytest.fixture(params=[x for x in ENGINES.keys() if x != "hive"])
 def iter_engines(request) -> Generator[Engine, None, None]:
     """Return an iterable of sqlalchemy in-memory engines to test."""
     engine = ENGINES[request.param]
     yield create_engine(engine["url"], *engine["connect_args"], **engine["kwargs"])
 
 
+@pytest.fixture(params=[x for x in ENGINES.keys() if x != "hive"])
+def iter_stores_by_engine(request) -> Generator[Store, None, None]:
+    """Return an iterable of stores with different engines to test.
+    Will only return engines that support data ingestion.
+    """
+    engine = ENGINES[request.param]
+    engine = create_engine(engine["url"], *engine["connect_args"], **engine["kwargs"])
+    store = Store(engine=engine)
+    yield store
+
+
 @pytest.fixture(params=ENGINES.keys())
+def iter_stores_by_engine_no_data_ingestion(request) -> Generator[Store, None, None]:
+    """Return an iterable of stores with different engines to test."""
+    engine = ENGINES[request.param]
+    if engine["url"].startswith("hive"):
+        store = Store.create_new_hive_store(
+            engine["url"], *engine["connect_args"], drop_tables=True, **engine["kwargs"]
+        )
+    else:
+        engine = create_engine(engine["url"], *engine["connect_args"], **engine["kwargs"])
+        store = Store(engine=engine)
+    yield store
+
+
+@pytest.fixture(params=[x for x in ENGINES.keys() if x != "hive"])
 def iter_engines_file(request, tmp_path) -> Generator[Engine, None, None]:
     """Return an iterable of sqlalchemy file-based engines to test."""
     engine = ENGINES[request.param]
@@ -38,7 +68,7 @@ def iter_engines_file(request, tmp_path) -> Generator[Engine, None, None]:
     yield create_engine(url, *engine["connect_args"], **engine["kwargs"])
 
 
-@pytest.fixture(params=ENGINES.keys())
+@pytest.fixture(params=[x for x in ENGINES.keys() if x != "hive"])
 def iter_engine_names(request) -> Generator[str, None, None]:
     """Return an iterable of engine names."""
     yield request.param

--- a/tests/test_checker_representative_time.py
+++ b/tests/test_checker_representative_time.py
@@ -13,9 +13,8 @@ def ingest_data_and_check(
     engine: Engine, df: pd.DataFrame, schema: TableSchema, error: tuple[any, str]
 ) -> None:
     metadata = MetaData()
-    with engine.connect() as conn:
+    with engine.begin() as conn:
         write_database(df, conn, schema.name, [schema.time_config], if_table_exists="replace")
-        conn.commit()
     metadata.reflect(engine, views=True)
 
     with engine.connect() as conn:

--- a/tests/test_mapper_datetime_to_datetime.py
+++ b/tests/test_mapper_datetime_to_datetime.py
@@ -73,7 +73,7 @@ def run_test_with_error(
     metadata = MetaData()
     ingest_data(engine, df, from_schema)
     with pytest.raises(error[0], match=error[1]):
-        map_time(engine, metadata, from_schema, to_schema)
+        map_time(engine, metadata, from_schema, to_schema, check_mapped_timestamps=True)
 
 
 def get_mapped_results(
@@ -84,7 +84,7 @@ def get_mapped_results(
 ) -> pd.DataFrame:
     metadata = MetaData()
     ingest_data(engine, df, from_schema)
-    map_time(engine, metadata, from_schema, to_schema)
+    map_time(engine, metadata, from_schema, to_schema, check_mapped_timestamps=True)
 
     with engine.connect() as conn:
         query = f"select * from {to_schema.name}"

--- a/tests/test_mapper_datetime_to_datetime.py
+++ b/tests/test_mapper_datetime_to_datetime.py
@@ -58,9 +58,8 @@ def ingest_data(
     schema: TableSchema,
 ) -> None:
     metadata = MetaData()
-    with engine.connect() as conn:
+    with engine.begin() as conn:
         write_database(df, conn, schema.name, [schema.time_config], if_table_exists="replace")
-        conn.commit()
     metadata.reflect(engine, views=True)
 
 
@@ -128,7 +127,7 @@ def check_time_shift_values(
         assert row["value"] == dfo.loc[dfo["timestamp"] == ts, "value"].iloc[0]
 
 
-def test_roll_time_using_shift_and_wrap(iter_engines: Engine) -> None:
+def test_roll_time_using_shift_and_wrap() -> None:
     from_schema = get_datetime_schema(2024, None, TimeIntervalType.PERIOD_ENDING, "from_table")
     df = generate_datetime_dataframe(from_schema)
     to_schema = get_datetime_schema(2024, None, TimeIntervalType.PERIOD_BEGINNING, "to_table")

--- a/tests/test_mapper_representative_time_to_datetime.py
+++ b/tests/test_mapper_representative_time_to_datetime.py
@@ -22,7 +22,7 @@ def get_datetime_schema(year: int, tzinfo: ZoneInfo | None) -> TableSchema:
     start = datetime(year=year, month=1, day=1, tzinfo=tzinfo)
     end = datetime(year=year + 1, month=1, day=1, tzinfo=tzinfo)
     resolution = timedelta(hours=1)
-    length = (end - start) / resolution + 1
+    length = (end - start) / resolution
     schema = TableSchema(
         name="mapped_data",
         time_config=DatetimeRange(

--- a/tests/test_mapper_representative_time_to_datetime.py
+++ b/tests/test_mapper_representative_time_to_datetime.py
@@ -64,9 +64,9 @@ def run_test(
     # Map
     if error:
         with pytest.raises(error[0], match=error[1]):
-            map_time(engine, metadata, from_schema, to_schema)
+            map_time(engine, metadata, from_schema, to_schema, check_mapped_timestamps=True)
     else:
-        map_time(engine, metadata, from_schema, to_schema)
+        map_time(engine, metadata, from_schema, to_schema, check_mapped_timestamps=True)
 
         # Check mapped table
         with engine.connect() as conn:

--- a/tests/test_mapper_representative_time_to_datetime.py
+++ b/tests/test_mapper_representative_time_to_datetime.py
@@ -55,11 +55,10 @@ def run_test(
 ) -> None:
     # Ingest
     metadata = MetaData()
-    with engine.connect() as conn:
+    with engine.begin() as conn:
         write_database(
             df, conn, from_schema.name, [from_schema.time_config], if_table_exists="replace"
         )
-        conn.commit()
     metadata.reflect(engine, views=True)
 
     # Map

--- a/tests/test_path_utils.py
+++ b/tests/test_path_utils.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+import pytest
+
+from chronify.exceptions import InvalidOperation
+from chronify.utils.path_utils import check_overwrite, delete_if_exists, to_path
+
+
+def test_check_overwrite(tmp_path):
+    file_path = tmp_path / "file.txt"
+    directory = tmp_path / "test_dir"
+    check_overwrite(file_path, False)
+    check_overwrite(directory, False)
+
+    directory.mkdir()
+    file_path.touch()
+    for path in (directory, file_path):
+        assert path.exists()
+        with pytest.raises(InvalidOperation):
+            check_overwrite(path, False)
+        assert path.exists()
+        check_overwrite(path, True)
+        assert not path.exists()
+
+
+def test_delete_if_exists(tmp_path):
+    file_path = tmp_path / "file.txt"
+    directory = tmp_path / "test_dir"
+    delete_if_exists(file_path)
+    delete_if_exists(directory)
+
+    directory.mkdir()
+    file_path.touch()
+    for path in (directory, file_path):
+        assert path.exists()
+        delete_if_exists(path)
+        assert not path.exists()
+
+
+@pytest.mark.parametrize("value", ["file.txt", Path("file.txt")])
+def test_to_path(value):
+    assert isinstance(to_path(value), Path)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -408,7 +408,7 @@ def test_map_datetime_to_one_week_per_month_by_hour(
         store.create_view_from_parquet(out_file, src_schema)
     else:
         store.ingest_table(df, src_schema)
-    store.map_table_time_config(src_schema.name, dst_schema)
+    store.map_table_time_config(src_schema.name, dst_schema, check_mapped_timestamps=True)
     df2 = store.read_table(dst_schema.name)
     assert len(df2) == time_array_len * num_time_arrays
     actual = sorted(df2["timestamp"].unique())
@@ -427,7 +427,7 @@ def test_map_datetime_to_one_week_per_month_by_hour(
         assert out_file.exists()
 
     with pytest.raises(TableAlreadyExists):
-        store.map_table_time_config(src_schema.name, dst_schema)
+        store.map_table_time_config(src_schema.name, dst_schema, check_mapped_timestamps=True)
 
 
 @pytest.mark.parametrize("tzinfo", [ZoneInfo("EST"), None])
@@ -491,7 +491,9 @@ def test_map_datetime_to_datetime(
         output_file = tmp_path / "mapped_data"
     else:
         output_file = None
-    store.map_table_time_config(src_schema.name, dst_schema, output_file=output_file)
+    store.map_table_time_config(
+        src_schema.name, dst_schema, output_file=output_file, check_mapped_timestamps=True
+    )
     if output_file is None or store.engine.name == "sqlite":
         df2 = store.read_table(dst_schema.name)
     else:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -117,7 +117,6 @@ def test_ingest_csv(iter_stores_by_engine: Store, tmp_path, generators_schema, u
         ).to_df().to_csv(new_src_file, index=False)
         src_file = new_src_file
     store.ingest_from_csv(src_file, src_schema, dst_schema)
-    store.create_index(dst_schema.name)
     df = store.read_table(dst_schema.name)
     assert len(df) == 8784 * 3
 
@@ -148,8 +147,6 @@ def test_ingest_csv(iter_stores_by_engine: Store, tmp_path, generators_schema, u
     df = store.read_table(dst_schema.name)
     assert len(df) == 8784 * 3 * 2
     all(df.timestamp.unique() == expected_timestamps)
-
-    store.drop_index(dst_schema.name)
 
     # Read a subset of the table.
     df2 = store.read_query(

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -9,7 +9,16 @@ import duckdb
 import numpy as np
 import pandas as pd
 import pytest
-from sqlalchemy import DateTime, Double, Engine, Table, create_engine, select
+from sqlalchemy import (
+    Connection,
+    DateTime,
+    Double,
+    Engine,
+    Integer,
+    Table,
+    create_engine,
+    select,
+)
 
 from chronify.csv_io import read_csv
 from chronify.duckdb.functions import unpivot
@@ -18,6 +27,7 @@ from chronify.exceptions import (
     InvalidOperation,
     InvalidParameter,
     InvalidTable,
+    TableAlreadyExists,
     TableNotStored,
 )
 from chronify.models import ColumnDType, CsvTableSchema, PivotedTableSchema, TableSchema
@@ -62,14 +72,41 @@ def generators_schema():
     yield Path(GENERATOR_TIME_SERIES_FILE), src_schema, dst_schema
 
 
+@pytest.fixture
+def multiple_tables():
+    resolution = timedelta(hours=1)
+    df_base = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2020-01-01", "2020-12-31 23:00:00", freq=resolution),
+            "value": np.random.random(8784),
+        }
+    )
+    df1 = df_base.copy()
+    df2 = df_base.copy()
+    df1["id"] = 1
+    df2["id"] = 2
+    tables = [df1, df2]
+    schema = TableSchema(
+        name="devices",
+        value_column="value",
+        time_config=DatetimeRange(
+            time_column="timestamp",
+            start=datetime(2020, 1, 1, 0),
+            length=8784,
+            resolution=timedelta(hours=1),
+        ),
+        time_array_id_columns=["id"],
+    )
+    yield tables, schema
+
+
 @pytest.mark.parametrize("use_time_zone", [True, False])
-def test_ingest_csv(iter_engines: Engine, tmp_path, generators_schema, use_time_zone):
-    engine = iter_engines
+def test_ingest_csv(iter_stores_by_engine: Store, tmp_path, generators_schema, use_time_zone):
+    store = iter_stores_by_engine
     src_file, src_schema, dst_schema = generators_schema
     src_schema.column_dtypes[0] = ColumnDType(
         name="timestamp", dtype=DateTime(timezone=use_time_zone)
     )
-    store = Store(engine=engine)
     if use_time_zone:
         new_src_file = tmp_path / "gen_tz.csv"
         duckdb.sql(
@@ -127,47 +164,91 @@ def test_ingest_csv(iter_engines: Engine, tmp_path, generators_schema, use_time_
         store.ingest_from_csv(new_file, src_schema2, dst_schema)
 
 
-def test_ingest_multiple_tables(iter_engines: Engine):
-    store = Store(engine=iter_engines)
-    resolution = timedelta(hours=1)
-    df_base = pd.DataFrame(
-        {
-            "timestamp": pd.date_range("2020-01-01", "2020-12-31 23:00:00", freq=resolution),
-            "value": np.random.random(8784),
-        }
+def test_ingest_csvs_with_rollback(tmp_path, multiple_tables):
+    # Python sqlite3 does not appear to support rollbacks with DDL statements.
+    # See discussion at https://bugs.python.org/issue10740.
+    # TODO: needs investigation
+    # Most users won't care...and will be using duckdb since it is the default.
+    store = Store(engine_name="duckdb")
+    tables, dst_schema = multiple_tables
+    src_file1 = tmp_path / "file1.csv"
+    src_file2 = tmp_path / "file2.csv"
+    tables[0].to_csv(src_file1)
+    tables[1].to_csv(src_file2)
+    src_schema = CsvTableSchema(
+        time_config=dst_schema.time_config,
+        column_dtypes=[
+            ColumnDType(name="timestamp", dtype=DateTime()),
+            ColumnDType(name="id", dtype=Integer()),
+            ColumnDType(name="value", dtype=Double()),
+        ],
+        value_columns=[dst_schema.value_column],
+        time_array_id_columns=dst_schema.time_array_id_columns,
     )
-    df1 = df_base.copy()
-    df2 = df_base.copy()
-    df1["id"] = 1
-    df2["id"] = 2
-    store.ingest_tables(
-        [df1, df2],
-        TableSchema(
-            name="devices",
-            value_column="value",
-            time_config=DatetimeRange(
-                time_column="timestamp",
-                start=datetime(2020, 1, 1, 0),
-                length=8784,
-                resolution=timedelta(hours=1),
-            ),
-            time_array_id_columns=["id"],
-        ),
-    )
+
+    def check_data(conn: Connection):
+        df = store.read_table(dst_schema.name, connection=conn)
+        assert len(df) == len(tables[0]) + len(tables[1])
+        assert len(df.id.unique()) == 2
+
+    with store.engine.begin() as conn:
+        store.ingest_from_csvs((src_file1, src_file2), src_schema, dst_schema, connection=conn)
+        check_data(conn)
+        conn.rollback()
+
+    store.update_metadata()
+    assert not store.has_table(dst_schema.name)
+
+    with store.engine.begin() as conn:
+        store.ingest_from_csvs((src_file1, src_file2), src_schema, dst_schema, connection=conn)
+        check_data(conn)
+
+    with store.engine.begin() as conn:
+        check_data(conn)
+
+
+@pytest.mark.parametrize("existing_connection", [False, True])
+def test_ingest_multiple_tables(
+    iter_stores_by_engine: Store, multiple_tables, existing_connection: bool
+):
+    store = iter_stores_by_engine
+    tables, schema = multiple_tables
+    if existing_connection:
+        store.ingest_tables(tables, schema)
+    else:
+        with store.engine.begin() as conn:
+            store.ingest_tables(tables, schema, connection=conn)
     query = "SELECT * FROM devices WHERE id = ?"
     params = (2,)
-    df = store.read_query("devices", query, params=params)
+    with store.engine.connect() as conn:
+        df = store.read_query("devices", query, params=params, connection=conn)
     df["timestamp"] = df["timestamp"].astype("datetime64[ns]")
-    assert df.equals(df2)
+    assert df.equals(tables[1])
+
+
+def test_ingest_multiple_tables_error(iter_stores_by_engine: Store, multiple_tables):
+    store = iter_stores_by_engine
+    tables, schema = multiple_tables
+    orig_value = tables[1].loc[8783]["id"]
+    tables[1].loc[8783] = (tables[1].loc[8783]["timestamp"], 0.1, 99)
+    with pytest.raises(InvalidTable):
+        store.ingest_tables(tables, schema)
+    assert not store.has_table(schema.name)
+
+    tables[1].loc[8783] = (tables[1].loc[8783]["timestamp"], 0.1, orig_value)
+    store.ingest_tables(tables, schema)
+    params = (2,)
+    df = store.read_query(schema.name, f"select * from {schema.name} where id=?", params=params)
+    df["timestamp"] = df["timestamp"].astype("datetime64[ns]")
+    assert df.equals(tables[1])
 
 
 @pytest.mark.parametrize("use_pandas", [False, True])
-def test_ingest_pivoted_table(iter_engines: Engine, generators_schema, use_pandas: bool):
-    engine = iter_engines
+def test_ingest_pivoted_table(iter_stores_by_engine: Store, generators_schema, use_pandas: bool):
+    store = iter_stores_by_engine
     src_file, src_schema, dst_schema = generators_schema
     pivoted_schema = PivotedTableSchema(**src_schema.model_dump(exclude={"column_dtypes"}))
     rel = read_csv(src_file, src_schema)
-    store = Store(engine=engine)
     input_table = rel.to_df() if use_pandas else rel
     store.ingest_pivoted_table(input_table, pivoted_schema, dst_schema)
     table = store.get_table(dst_schema.name)
@@ -176,8 +257,8 @@ def test_ingest_pivoted_table(iter_engines: Engine, generators_schema, use_panda
     assert len(df) == 8784
 
 
-def test_ingest_invalid_csv(iter_engines: Engine, tmp_path, generators_schema):
-    engine = iter_engines
+def test_ingest_invalid_csv(iter_stores_by_engine: Store, tmp_path, generators_schema):
+    store = iter_stores_by_engine
     src_file, src_schema, dst_schema = generators_schema
     lines = src_file.read_text().splitlines()[:-10]
     new_file = tmp_path / "data.csv"
@@ -186,27 +267,26 @@ def test_ingest_invalid_csv(iter_engines: Engine, tmp_path, generators_schema):
             f.write(line)
             f.write("\n")
 
-    store = Store(engine=engine)
     with pytest.raises(InvalidTable):
         store.ingest_from_csv(new_file, src_schema, dst_schema)
     with pytest.raises(TableNotStored):
         store.read_table(dst_schema.name)
 
 
-def test_invalid_schema(iter_engines: Engine, generators_schema):
-    engine = iter_engines
+def test_invalid_schema(iter_stores_by_engine: Store, generators_schema):
+    store = iter_stores_by_engine
     src_file, src_schema, dst_schema = generators_schema
     src_schema.value_columns = ["g1", "g2", "g3"]
-    store = Store(engine=engine)
     with pytest.raises(InvalidTable):
         store.ingest_from_csv(src_file, src_schema, dst_schema)
 
 
-def test_ingest_one_week_per_month_by_hour(iter_engines: Engine, one_week_per_month_by_hour_table):
-    engine = iter_engines
+def test_ingest_one_week_per_month_by_hour(
+    iter_stores_by_engine: Store, one_week_per_month_by_hour_table
+):
+    store = iter_stores_by_engine
     df, num_time_arrays, schema = one_week_per_month_by_hour_table
 
-    store = Store(engine=engine)
     store.ingest_table(df, schema)
     df2 = store.read_table(schema.name)
     assert len(df2["id"].unique()) == num_time_arrays
@@ -217,19 +297,23 @@ def test_ingest_one_week_per_month_by_hour(iter_engines: Engine, one_week_per_mo
 
 
 def test_ingest_one_week_per_month_by_hour_invalid(
-    iter_engines: Engine, one_week_per_month_by_hour_table
+    iter_stores_by_engine: Store, one_week_per_month_by_hour_table
 ):
-    engine = iter_engines
+    store = iter_stores_by_engine
     df, _, schema = one_week_per_month_by_hour_table
     df_filtered = df[df["hour"] != 5]
     assert len(df_filtered) < len(df)
 
-    store = Store(engine=engine)
     with pytest.raises(InvalidTable):
         store.ingest_table(df_filtered, schema)
 
 
-def test_load_parquet(tmp_path):
+def test_load_parquet(iter_stores_by_engine_no_data_ingestion: Store, tmp_path):
+    store = iter_stores_by_engine_no_data_ingestion
+    if store.engine.name == "sqlite":
+        # SQLite doesn't support parquet
+        return
+
     time_config = DatetimeRange(
         start=datetime(year=2020, month=1, day=1, tzinfo=ZoneInfo("EST")),
         resolution=timedelta(hours=1),
@@ -260,8 +344,7 @@ def test_load_parquet(tmp_path):
     rel2 = unpivot(rel, ("gen1", "gen2", "gen3"), "generator", "value")  # noqa: F841
     out_file = tmp_path / "gen2.parquet"
     rel2.to_parquet(str(out_file))
-    store = Store()
-    store.load_table(out_file, dst_schema)
+    store.create_view_from_parquet(out_file, dst_schema)
     df = store.read_table(dst_schema.name)
     assert len(df) == 8784 * 3
     timestamp_generator = make_time_range_generator(time_config)
@@ -279,9 +362,12 @@ def test_load_parquet(tmp_path):
     ],
 )
 def test_map_datetime_to_one_week_per_month_by_hour(
-    iter_engines: Engine, one_week_per_month_by_hour_table, params: tuple[bool, int]
+    tmp_path,
+    iter_stores_by_engine_no_data_ingestion: Store,
+    one_week_per_month_by_hour_table,
+    params: tuple[bool, int],
 ):
-    engine = iter_engines
+    store = iter_stores_by_engine_no_data_ingestion
     use_time_zone, year = params
     df, num_time_arrays, src_schema = one_week_per_month_by_hour_table
     if use_time_zone:
@@ -290,7 +376,7 @@ def test_map_datetime_to_one_week_per_month_by_hour(
         )
         src_schema.time_array_id_columns += ["time_zone"]
     tzinfo = ZoneInfo("America/Denver") if use_time_zone else None
-    time_array_len = 8784 if year % 4 else 8760
+    time_array_len = 8784 if year % 4 == 0 else 8760
     dst_schema = TableSchema(
         name="ev_charging_datetime",
         value_column="value",
@@ -302,8 +388,12 @@ def test_map_datetime_to_one_week_per_month_by_hour(
         ),
         time_array_id_columns=["id"],
     )
-    store = Store(engine=engine)
-    store.ingest_table(df, src_schema)
+    if store.engine.name == "hive":
+        out_file = tmp_path / "data.parquet"
+        df.to_parquet(out_file)
+        store.create_view_from_parquet(out_file, src_schema)
+    else:
+        store.ingest_table(df, src_schema)
     store.map_table_time_config(src_schema.name, dst_schema)
     df2 = store.read_table(dst_schema.name)
     assert len(df2) == time_array_len * num_time_arrays
@@ -311,6 +401,85 @@ def test_map_datetime_to_one_week_per_month_by_hour(
     expected = make_time_range_generator(dst_schema.time_config).list_timestamps()
     if use_time_zone:
         expected = [pd.Timestamp(x) for x in expected]
+    check_timestamp_lists(actual, expected)
+
+    out_file = tmp_path / "out.parquet"
+    assert not out_file.exists()
+    if store.engine.name == "sqlite":
+        with pytest.raises(NotImplementedError):
+            store.write_table_to_parquet(dst_schema.name, out_file)
+    else:
+        store.write_table_to_parquet(dst_schema.name, out_file, overwrite=True)
+        assert out_file.exists()
+
+    with pytest.raises(TableAlreadyExists):
+        store.map_table_time_config(src_schema.name, dst_schema)
+
+
+@pytest.mark.parametrize("tzinfo", [ZoneInfo("EST"), None])
+def test_map_datetime_to_datetime(
+    tmp_path, iter_stores_by_engine_no_data_ingestion: Store, tzinfo
+):
+    store = iter_stores_by_engine_no_data_ingestion
+    time_array_len = 8784
+    year = 2020
+
+    src_time_config = DatetimeRange(
+        start=datetime(year=year, month=1, day=1, hour=0, tzinfo=tzinfo),
+        resolution=timedelta(hours=1),
+        length=time_array_len,
+        interval_type=TimeIntervalType.PERIOD_BEGINNING,
+        time_column="timestamp",
+    )
+    dst_time_config = DatetimeRange(
+        start=datetime(year=year, month=1, day=1, hour=1, tzinfo=tzinfo),
+        resolution=timedelta(hours=1),
+        length=time_array_len,
+        interval_type=TimeIntervalType.PERIOD_ENDING,
+        time_column="timestamp",
+    )
+
+    src_csv_schema = CsvTableSchema(
+        time_config=src_time_config,
+        column_dtypes=[
+            ColumnDType(name="timestamp", dtype=DateTime(timezone=False)),
+            ColumnDType(name="gen1", dtype=Double()),
+            ColumnDType(name="gen2", dtype=Double()),
+            ColumnDType(name="gen3", dtype=Double()),
+        ],
+        value_columns=["gen1", "gen2", "gen3"],
+        pivoted_dimension_name="generator",
+        time_array_id_columns=[],
+    )
+    dst_schema = TableSchema(
+        name="generators_pe",
+        time_config=dst_time_config,
+        time_array_id_columns=["generator"],
+        value_column="value",
+    )
+    rel = read_csv(GENERATOR_TIME_SERIES_FILE, src_csv_schema)
+    rel2 = unpivot(rel, ("gen1", "gen2", "gen3"), "generator", "value")  # noqa: F841
+
+    src_schema = TableSchema(
+        name="generators_pb",
+        time_config=src_time_config,
+        time_array_id_columns=["generator"],
+        value_column="value",
+    )
+    if store.engine.name == "hive":
+        out_file = tmp_path / "data.parquet"
+        rel2.to_df().to_parquet(out_file)
+        store.create_view_from_parquet(out_file, src_schema)
+    else:
+        store.ingest_table(rel2, src_schema)
+
+    store.map_table_time_config(src_schema.name, dst_schema)
+    df2 = store.read_table(dst_schema.name)
+    assert len(df2) == time_array_len * 3
+    actual = sorted(df2["timestamp"].unique())
+    assert isinstance(src_schema.time_config, DatetimeRange)
+    assert actual[0] == src_schema.time_config.start + timedelta(hours=1)
+    expected = make_time_range_generator(dst_schema.time_config).list_timestamps()
     check_timestamp_lists(actual, expected)
 
 
@@ -321,7 +490,7 @@ def test_to_parquet(tmp_path, generators_schema):
     filename = tmp_path / "data.parquet"
     table = Table(dst_schema.name, store.metadata)
     stmt = select(table).where(table.c.generator == "gen2")
-    store.write_query_to_parquet(stmt, filename)
+    store.write_query_to_parquet(stmt, filename, overwrite=True)
     assert filename.exists()
     df = pd.read_parquet(filename)
     assert len(df) == 8784
@@ -339,6 +508,8 @@ def test_load_existing_store(iter_engines_file, one_week_per_month_by_hour_table
     store2 = Store.load_from_file(engine_name=engine.name, file_path=file_path)
     df3 = store2.read_table(schema.name)
     assert df3.equals(df2)
+    with pytest.raises(FileNotFoundError):
+        Store.load_from_file(engine_name=engine.name, file_path="./invalid/path")
 
 
 def test_create_methods(iter_engine_names, tmp_path):
@@ -351,6 +522,16 @@ def test_create_methods(iter_engine_names, tmp_path):
         Store.create_file_db(engine_name=iter_engine_names, file_path=path)
     Store.create_file_db(engine_name=iter_engine_names, file_path=path, overwrite=True)
     Store.create_in_memory_db(engine_name=iter_engine_names)
+
+
+def test_invalid_hive_url():
+    with pytest.raises(InvalidParameter):
+        Store.create_new_hive_store("duckdb:///:memory:")
+
+
+def test_invalid_engine():
+    with pytest.raises(NotImplementedError):
+        Store(engine_name="hive")
 
 
 def test_create_with_existing_engine():
@@ -381,7 +562,7 @@ def test_backup(iter_engines_file: Engine, one_week_per_month_by_hour_table, tmp
     df2 = store2.read_table(schema.name)
     assert df2.equals(df)
 
-    with pytest.raises(InvalidParameter):
+    with pytest.raises(InvalidOperation):
         store.backup(dst_file)
     dst_file2 = tmp_path / "backup2.db"
     dst_file2.touch()
@@ -404,10 +585,9 @@ def test_backup_not_allowed(one_week_per_month_by_hour_table, tmp_path):
     assert not dst_file.exists()
 
 
-def test_delete_rows(iter_engines: Engine, one_week_per_month_by_hour_table):
-    engine = iter_engines
+def test_delete_rows(iter_stores_by_engine: Store, one_week_per_month_by_hour_table):
+    store = iter_stores_by_engine
     df, _, schema = one_week_per_month_by_hour_table
-    store = Store(engine=engine)
     store.ingest_table(df, schema)
     df2 = store.read_table(schema.name)
     assert df2.equals(df)
@@ -417,7 +597,8 @@ def test_delete_rows(iter_engines: Engine, one_week_per_month_by_hour_table):
     store.delete_rows(schema.name, {"id": 2})
     df3 = store.read_table(schema.name)
     assert sorted(df3["id"].unique()) == [1, 3]
-    store.delete_rows(schema.name, {"id": 1})
+    with store.engine.begin() as conn:
+        store.delete_rows(schema.name, {"id": 1}, connection=conn)
     df4 = store.read_table(schema.name)
     assert sorted(df4["id"].unique()) == [3]
     store.delete_rows(schema.name, {"id": 3})
@@ -427,10 +608,9 @@ def test_delete_rows(iter_engines: Engine, one_week_per_month_by_hour_table):
         store.delete_rows(schema.name, {"id": 3})
 
 
-def test_drop_table(iter_engines: Engine, one_week_per_month_by_hour_table):
-    engine = iter_engines
+def test_drop_table(iter_stores_by_engine: Store, one_week_per_month_by_hour_table):
+    store = iter_stores_by_engine
     df, _, schema = one_week_per_month_by_hour_table
-    store = Store(engine=engine)
     assert not store.list_tables()
     store.ingest_table(df, schema)
     assert store.read_table(schema.name).equals(df)
@@ -443,10 +623,9 @@ def test_drop_table(iter_engines: Engine, one_week_per_month_by_hour_table):
         store.drop_table(schema.name)
 
 
-def test_drop_view(iter_engines: Engine, one_week_per_month_by_hour_table):
-    engine = iter_engines
+def test_drop_view(iter_stores_by_engine: Store, one_week_per_month_by_hour_table):
+    store = iter_stores_by_engine
     df, _, schema = one_week_per_month_by_hour_table
-    store = Store(engine=engine)
     store.ingest_table(df, schema)
     table = Table(schema.name, store.metadata)
     stmt = select(table).where(table.c.id == 1)
@@ -459,10 +638,9 @@ def test_drop_view(iter_engines: Engine, one_week_per_month_by_hour_table):
     assert schema2.name not in store.list_tables()
 
 
-def test_read_raw_query(iter_engines: Engine, one_week_per_month_by_hour_table):
-    engine = iter_engines
+def test_read_raw_query(iter_stores_by_engine: Store, one_week_per_month_by_hour_table):
+    store = iter_stores_by_engine
     df, _, schema = one_week_per_month_by_hour_table
-    store = Store(engine=engine)
     store.ingest_table(df, schema)
 
     query = f"SELECT * FROM {schema.name}"
@@ -471,5 +649,6 @@ def test_read_raw_query(iter_engines: Engine, one_week_per_month_by_hour_table):
 
     query = f"SELECT * FROM {schema.name} where id = ?"
     params = (2,)
-    df2 = store.read_raw_query(query, params=params)
+    with store.engine.connect() as conn:
+        df2 = store.read_raw_query(query, params=params, connection=conn)
     assert df2.equals(df[df["id"] == 2].reset_index(drop=True))

--- a/tests/test_time_series_checker.py
+++ b/tests/test_time_series_checker.py
@@ -77,9 +77,8 @@ def _run_test(
         time_array_id_columns=["generator"],
         value_column="value",
     )
-    with engine.connect() as conn:
+    with engine.begin() as conn:
         write_database(df, conn, schema.name, [schema.time_config], if_table_exists="replace")
-        conn.commit()
     metadata.reflect(engine)
 
     with engine.connect() as conn:


### PR DESCRIPTION
1. Add support for PyHive backends. This is an optional dependency. dsgrid will use it. There are some things that are not perfect, notably handling of timestamps when creating tables (there are workarounds). I'd like to move forward as-is and make improvements later. 
2. Add option to write the destination of a map-table operation to a Parquet file instead of the database. This is for dsgrid primarily, but other users might want that.
3. Add options to skip time checks on the mapped table. dsgrid won't want to do this extra work on huge tables. It shouldn't be required, but we can talk about it.
4. Refactor commit/rollback handling in `ingest_table`. There were corner cases not covered, especially with SQLite.
5. Refactor `write_database` and `read_database`. The addition of hive necessitated some reorganization. I found that we really don't need Polars anymore, and so removed it from the repo.
6. Added `ignore_columns` to `TableSchema`. This allows users to include columns that chronify ignores.