### PR TITLE
Map time resolution

### DIFF
--- a/src/chronify/store.py
+++ b/src/chronify/store.py
@@ -51,6 +51,7 @@ from chronify.time_series_checker import check_timestamps
 from chronify.time_series_mapper import map_time
 from chronify.utils.path_utils import check_overwrite, to_path
 from chronify.utils.sqlalchemy_view import create_view
+from chronify.time import ResamplingOperationType
 
 
 class Store:
@@ -845,6 +846,7 @@ class Store:
         dst_schema: TableSchema,
         data_adjustment: Optional[TimeBasedDataAdjustment] = None,
         wrap_time_allowed: bool = False,
+        resampling_operation: Optional[ResamplingOperationType] = None,
         scratch_dir: Optional[Path] = None,
         output_file: Optional[Path] = None,
         check_mapped_timestamps: bool = False,
@@ -864,6 +866,9 @@ class Store:
         wrap_time_allowed
             Defines whether the time column is allowed to be wrapped according to the time
             config in dst_schema when it does not line up with the time config
+        resampling_operation
+            Defines the operation type for resampling when the time resolution in the source
+            data differs from the dst_schema
         scratch_dir
             Directory to use for temporary writes. Default to the system's tmp filesystem.
         check_mapped_timestamps
@@ -929,6 +934,7 @@ class Store:
             dst_schema,
             data_adjustment=data_adjustment,
             wrap_time_allowed=wrap_time_allowed,
+            resampling_operation=resampling_operation,
             scratch_dir=scratch_dir,
             output_file=output_file,
             check_mapped_timestamps=check_mapped_timestamps,

--- a/src/chronify/time.py
+++ b/src/chronify/time.py
@@ -1,7 +1,7 @@
 """Definitions related to time"""
 
 from enum import StrEnum
-from typing import NamedTuple
+from typing import NamedTuple, Union
 from zoneinfo import ZoneInfo
 
 from chronify.exceptions import InvalidParameter
@@ -112,6 +112,27 @@ class MeasurementType(StrEnum):
     # description="Data values represent the measured value at that reported time",
     TOTAL = "total"
     # description="Data values represent the sum of values in a time range",
+
+
+class AggregationType(StrEnum):
+    """Operation types for resampling / aggregation"""
+
+    SUM = "sum"
+    AVG = "avg"
+    MIN = "min"
+    MAX = "max"
+
+
+class DisaggregationType(StrEnum):
+    """Operation types for resampling / disaggregation"""
+
+    INTERPOLATE = "interpolate"
+    DUPLICATE_FFILL = "duplicate_ffill"
+    DUPLICATE_BFILL = "duplicate_bfill"
+    UNIFORM_DISAGGREGATE = "uniform_disaggregate"
+
+
+ResamplingOperationType = Union[AggregationType, DisaggregationType]
 
 
 class TimeZone(StrEnum):

--- a/src/chronify/time_series_mapper.py
+++ b/src/chronify/time_series_mapper.py
@@ -17,6 +17,7 @@ from chronify.time_configs import (
     TimeBasedDataAdjustment,
     ColumnRepresentativeBase,
 )
+from chronify.time import ResamplingOperationType
 
 
 def map_time(
@@ -26,6 +27,7 @@ def map_time(
     to_schema: TableSchema,
     data_adjustment: Optional[TimeBasedDataAdjustment] = None,
     wrap_time_allowed: bool = False,
+    resampling_operation: Optional[ResamplingOperationType] = None,
     scratch_dir: Optional[Path] = None,
     output_file: Optional[Path] = None,
     check_mapped_timestamps: bool = False,
@@ -35,7 +37,13 @@ def map_time(
         to_schema.time_config, DatetimeRange
     ):
         MapperRepresentativeTimeToDatetime(
-            engine, metadata, from_schema, to_schema, data_adjustment, wrap_time_allowed
+            engine,
+            metadata,
+            from_schema,
+            to_schema,
+            data_adjustment,
+            wrap_time_allowed,
+            resampling_operation,
         ).map_time(
             scratch_dir=scratch_dir,
             output_file=output_file,
@@ -45,7 +53,13 @@ def map_time(
         to_schema.time_config, DatetimeRange
     ):
         MapperDatetimeToDatetime(
-            engine, metadata, from_schema, to_schema, data_adjustment, wrap_time_allowed
+            engine,
+            metadata,
+            from_schema,
+            to_schema,
+            data_adjustment,
+            wrap_time_allowed,
+            resampling_operation,
         ).map_time(
             scratch_dir=scratch_dir,
             output_file=output_file,
@@ -55,7 +69,13 @@ def map_time(
         to_schema.time_config, DatetimeRange
     ):
         MapperIndexTimeToDatetime(
-            engine, metadata, from_schema, to_schema, data_adjustment, wrap_time_allowed
+            engine,
+            metadata,
+            from_schema,
+            to_schema,
+            data_adjustment,
+            wrap_time_allowed,
+            resampling_operation,
         ).map_time(
             scratch_dir=scratch_dir,
             output_file=output_file,
@@ -67,7 +87,13 @@ def map_time(
         # No way to generate expected timestamps for YearMonthDayPeriodTimeNTZ
         # Is there a way to only check the output datetime timestamps?
         MapperColumnRepresentativeToDatetime(
-            engine, metadata, from_schema, to_schema, data_adjustment, wrap_time_allowed
+            engine,
+            metadata,
+            from_schema,
+            to_schema,
+            data_adjustment,
+            wrap_time_allowed,
+            resampling_operation,
         ).map_time(
             scratch_dir=scratch_dir,
             output_file=output_file,

--- a/src/chronify/time_series_mapper_base.py
+++ b/src/chronify/time_series_mapper_base.py
@@ -18,7 +18,7 @@ from chronify.models import TableSchema, MappingTableSchema
 from chronify.exceptions import ConflictingInputsError
 from chronify.utils.sqlalchemy_table import create_table
 from chronify.time_series_checker import check_timestamps
-from chronify.time import TimeIntervalType
+from chronify.time import TimeIntervalType, ResamplingOperationType
 from chronify.time_configs import TimeBasedDataAdjustment
 
 
@@ -33,6 +33,7 @@ class TimeSeriesMapperBase(abc.ABC):
         to_schema: TableSchema,
         data_adjustment: Optional[TimeBasedDataAdjustment] = None,
         wrap_time_allowed: bool = False,
+        resampling_operation: Optional[ResamplingOperationType] = None,
     ) -> None:
         self._engine = engine
         self._metadata = metadata
@@ -45,6 +46,7 @@ class TimeSeriesMapperBase(abc.ABC):
             self._from_schema.time_config.interval_type
             != self._to_schema.time_config.interval_type
         )
+        self._resampling_operation = resampling_operation
 
     @abc.abstractmethod
     def check_schema_consistency(self) -> None:

--- a/src/chronify/time_series_mapper_base.py
+++ b/src/chronify/time_series_mapper_base.py
@@ -194,6 +194,8 @@ def _apply_mapping(
     select_stmt += [right_table.c[x] for x in right_cols]
 
     tval_col = left_table.c[val_col]
+    if "factor" in right_table_columns:
+        tval_col *= right_table.c["factor"]
     if not resampling_operation:
         select_stmt.append(tval_col)
     else:
@@ -227,7 +229,8 @@ def _apply_mapping(
     if resampling_operation:
         query = query.group_by(*groupby_stmt)
 
-        # TODO <---
+        # # TODO <---
+        # from chronify.sqlalchemy.functions import read_database
         # with engine.connect() as conn:
         #     df_map = read_database(f"select * from {mapping_table_name}", conn, to_schema.time_config)
         #     df = read_database(query, conn, to_schema.time_config)

--- a/src/chronify/time_series_mapper_base.py
+++ b/src/chronify/time_series_mapper_base.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 import pandas as pd
 from loguru import logger
-from sqlalchemy import Engine, MetaData, Table, select, text
+from sqlalchemy import Engine, MetaData, Table, select, text, func
 from chronify.hive_functions import create_materialized_view
 
 from chronify.sqlalchemy.functions import (
@@ -18,7 +18,7 @@ from chronify.models import TableSchema, MappingTableSchema
 from chronify.exceptions import ConflictingInputsError
 from chronify.utils.sqlalchemy_table import create_table
 from chronify.time_series_checker import check_timestamps
-from chronify.time import TimeIntervalType, ResamplingOperationType
+from chronify.time import TimeIntervalType, ResamplingOperationType, AggregationType
 from chronify.time_configs import TimeBasedDataAdjustment
 
 
@@ -93,6 +93,7 @@ def apply_mapping(
     engine: Engine,
     metadata: MetaData,
     data_adjustment: TimeBasedDataAdjustment,
+    resampling_operation: Optional[ResamplingOperationType] = None,
     scratch_dir: Optional[Path] = None,
     output_file: Optional[Path] = None,
     check_mapped_timestamps: bool = False,
@@ -118,6 +119,7 @@ def apply_mapping(
             to_schema,
             engine,
             metadata,
+            resampling_operation,
             scratch_dir,
             output_file,
         )
@@ -130,6 +132,11 @@ def apply_mapping(
             mapped_table = Table(to_schema.name, metadata)
             with engine.connect() as conn:
                 try:
+                    # TODO <---
+                    # if resampling_operation:
+                    # with engine.connect() as conn:
+                    #     df = read_database(f"select * from {mapped_table.name}", conn, to_schema.time_config)
+                    # breakpoint()
                     check_timestamps(
                         conn,
                         mapped_table,
@@ -163,6 +170,7 @@ def _apply_mapping(
     to_schema: TableSchema,
     engine: Engine,
     metadata: MetaData,
+    resampling_operation: Optional[ResamplingOperationType] = None,
     scratch_dir: Optional[Path] = None,
     output_file: Optional[Path] = None,
 ) -> None:
@@ -177,12 +185,31 @@ def _apply_mapping(
         set(from_schema.list_columns())
     )
 
+    val_col = to_schema.value_column  # from left_table
     final_cols = set(to_schema.list_columns()).union(left_table_pass_thru_columns)
     right_cols = set(right_table_columns).intersection(final_cols)
-    left_cols = final_cols - right_cols
+    left_cols = final_cols - right_cols - {val_col}
 
     select_stmt = [left_table.c[x] for x in left_cols]
     select_stmt += [right_table.c[x] for x in right_cols]
+
+    tval_col = left_table.c[val_col]
+    if not resampling_operation:
+        select_stmt.append(tval_col)
+    else:
+        groupby_stmt = select_stmt.copy()
+        match resampling_operation:
+            case AggregationType.SUM:
+                select_stmt.append(func.sum(tval_col).label(val_col))
+            case AggregationType.AVG:
+                select_stmt.append(func.avg(tval_col).label(val_col))
+            case AggregationType.MIN:
+                select_stmt.append(func.min(tval_col).label(val_col))
+            case AggregationType.MAX:
+                select_stmt.append(func.max(tval_col).label(val_col))
+            case _:
+                msg = f"Unsupported {resampling_operation=}"
+                raise ValueError(msg)
 
     keys = from_schema.time_config.list_time_columns()
     # check time_zone
@@ -197,6 +224,14 @@ def _apply_mapping(
 
     on_stmt = reduce(and_, (left_table.c[x] == right_table.c["from_" + x] for x in keys))
     query = select(*select_stmt).select_from(left_table).join(right_table, on_stmt)
+    if resampling_operation:
+        query = query.group_by(*groupby_stmt)
+
+        # TODO <---
+        # with engine.connect() as conn:
+        #     df_map = read_database(f"select * from {mapping_table_name}", conn, to_schema.time_config)
+        #     df = read_database(query, conn, to_schema.time_config)
+        # breakpoint()
 
     if output_file is not None:
         write_query_to_parquet(engine, str(query), output_file, overwrite=True)

--- a/src/chronify/time_series_mapper_column_representative_to_datetime.py
+++ b/src/chronify/time_series_mapper_column_representative_to_datetime.py
@@ -20,6 +20,7 @@ from chronify.datetime_range_generator import DatetimeRangeGenerator
 from chronify.models import MappingTableSchema, TableSchema
 from chronify.sqlalchemy.functions import read_database, write_database
 from chronify.utils.sqlalchemy_table import create_table
+from chronify.time import ResamplingOperationType
 
 
 class MapperColumnRepresentativeToDatetime(TimeSeriesMapperBase):
@@ -57,9 +58,16 @@ class MapperColumnRepresentativeToDatetime(TimeSeriesMapperBase):
         to_schema: TableSchema,
         data_adjustment: Optional[TimeBasedDataAdjustment] = None,
         wrap_time_allowed: bool = False,
+        resampling_operation: Optional[ResamplingOperationType] = None,
     ) -> None:
         super().__init__(
-            engine, metadata, from_schema, to_schema, data_adjustment, wrap_time_allowed
+            engine,
+            metadata,
+            from_schema,
+            to_schema,
+            data_adjustment,
+            wrap_time_allowed,
+            resampling_operation,
         )
 
         if not isinstance(to_schema.time_config, DatetimeRange):

--- a/src/chronify/time_series_mapper_column_representative_to_datetime.py
+++ b/src/chronify/time_series_mapper_column_representative_to_datetime.py
@@ -113,9 +113,10 @@ class MapperColumnRepresentativeToDatetime(TimeSeriesMapperBase):
             self._engine,
             self._metadata,
             self._data_adjustment,
-            scratch_dir,
-            output_file,
-            check_mapped_timestamps,
+            resampling_operation=self._resampling_operation,
+            scratch_dir=scratch_dir,
+            output_file=output_file,
+            check_mapped_timestamps=check_mapped_timestamps,
         )
 
         if drop_table:

--- a/src/chronify/time_series_mapper_index_time.py
+++ b/src/chronify/time_series_mapper_index_time.py
@@ -116,7 +116,9 @@ class MapperIndexTimeToDatetime(TimeSeriesMapperBase):
             self._engine,
             self._metadata,
             TimeBasedDataAdjustment(),
+            resampling_operation=None,
             scratch_dir=scratch_dir,
+            output_file=None,
             check_mapped_timestamps=False,
         )
 
@@ -128,6 +130,7 @@ class MapperIndexTimeToDatetime(TimeSeriesMapperBase):
             self._to_schema,
             self._data_adjustment,
             self._wrap_time_allowed,
+            resampling_operation=self._resampling_operation,
         ).map_time(
             scratch_dir=scratch_dir,
             output_file=output_file,

--- a/src/chronify/time_series_mapper_index_time.py
+++ b/src/chronify/time_series_mapper_index_time.py
@@ -69,7 +69,7 @@ class MapperIndexTimeToDatetime(TimeSeriesMapperBase):
     def _check_time_length(self) -> None:
         flen, tlen = self._from_time_config.length, self._to_time_config.length
         if flen != tlen and not self._wrap_time_allowed:
-            msg = f"Length must match between {self._from_schema.__class__} from_schema and {self._to_schema.__class__} to_schema. {flen} vs. {tlen} OR wrap_time_allowed must be set to True"
+            msg = f"Length must match between from_time_config and to_time_config. {flen} vs. {tlen} OR wrap_time_allowed must be set to True"
             raise ConflictingInputsError(msg)
 
     def map_time(

--- a/src/chronify/time_series_mapper_index_time.py
+++ b/src/chronify/time_series_mapper_index_time.py
@@ -17,7 +17,7 @@ from chronify.time_configs import (
 )
 from chronify.time_range_generator_factory import make_time_range_generator
 from chronify.time_series_mapper_datetime import MapperDatetimeToDatetime
-from chronify.time import TimeType, DaylightSavingAdjustmentType
+from chronify.time import TimeType, DaylightSavingAdjustmentType, ResamplingOperationType
 from chronify.sqlalchemy.functions import read_database
 
 logger = logging.getLogger(__name__)
@@ -32,9 +32,16 @@ class MapperIndexTimeToDatetime(TimeSeriesMapperBase):
         to_schema: TableSchema,
         data_adjustment: Optional[TimeBasedDataAdjustment] = None,
         wrap_time_allowed: bool = False,
+        resampling_operation: Optional[ResamplingOperationType] = None,
     ) -> None:
         super().__init__(
-            engine, metadata, from_schema, to_schema, data_adjustment, wrap_time_allowed
+            engine,
+            metadata,
+            from_schema,
+            to_schema,
+            data_adjustment,
+            wrap_time_allowed,
+            resampling_operation,
         )
         self._dst_adjustment = self._data_adjustment.daylight_saving_adjustment
         if not isinstance(self._from_schema.time_config, IndexTimeRangeBase):

--- a/src/chronify/time_series_mapper_representative.py
+++ b/src/chronify/time_series_mapper_representative.py
@@ -20,6 +20,7 @@ from chronify.time_configs import (
     TimeBasedDataAdjustment,
 )
 from chronify.time_utils import shift_time_interval
+from chronify.time import ResamplingOperationType
 
 logger = logging.getLogger(__name__)
 
@@ -33,9 +34,16 @@ class MapperRepresentativeTimeToDatetime(TimeSeriesMapperBase):
         to_schema: TableSchema,
         data_adjustment: Optional[TimeBasedDataAdjustment] = None,
         wrap_time_allowed: bool = False,
+        resampling_operation: Optional[ResamplingOperationType] = None,
     ) -> None:
         super().__init__(
-            engine, metadata, from_schema, to_schema, data_adjustment, wrap_time_allowed
+            engine,
+            metadata,
+            from_schema,
+            to_schema,
+            data_adjustment,
+            wrap_time_allowed,
+            resampling_operation,
         )
         if not isinstance(from_schema.time_config, RepresentativePeriodTimeBase):
             msg = "source schema does not have RepresentativePeriodTimeBase time config. Use a different mapper."

--- a/src/chronify/time_series_mapper_representative.py
+++ b/src/chronify/time_series_mapper_representative.py
@@ -80,6 +80,7 @@ class MapperRepresentativeTimeToDatetime(TimeSeriesMapperBase):
             self._engine,
             self._metadata,
             self._data_adjustment,
+            resampling_operation=self._resampling_operation,
             scratch_dir=scratch_dir,
             output_file=output_file,
             check_mapped_timestamps=check_mapped_timestamps,

--- a/tests/test_mapper_datetime_to_datetime.py
+++ b/tests/test_mapper_datetime_to_datetime.py
@@ -188,9 +188,9 @@ def test_time_interval_shift_different_time_ranges(
 @pytest.mark.parametrize(
     "tzinfo_tuple",
     [
-        # (ZoneInfo("US/Eastern"), None),
+        (ZoneInfo("US/Eastern"), None),
         (None, ZoneInfo("EST")),
-        # (ZoneInfo("US/Eastern"), ZoneInfo("US/Mountain")),
+        (ZoneInfo("US/Eastern"), ZoneInfo("US/Mountain")),
     ],
 )
 def test_time_shift_different_timezones(

--- a/tests/test_mapper_datetime_to_datetime.py
+++ b/tests/test_mapper_datetime_to_datetime.py
@@ -168,25 +168,6 @@ def test_time_interval_shift(
     check_time_shift_values(df, queried, from_schema.time_config, to_schema.time_config)
 
 
-@pytest.mark.parametrize("tzinfo", [ZoneInfo("US/Eastern")])  # , None])
-def test_map_time_resolution(
-    iter_engines: Engine,
-    tzinfo: ZoneInfo | None,
-) -> None:
-    from_schema = get_datetime_schema(
-        2020, tzinfo, TimeIntervalType.PERIOD_BEGINNING, "from_table"
-    )
-    df = generate_datetime_dataframe(from_schema)
-    to_schema = get_datetime_schema(2020, tzinfo, TimeIntervalType.PERIOD_ENDING, "to_table")
-    to_schema.time_config.resolution = timedelta(minutes=30)
-
-    breakpoint()
-
-    queried = get_mapped_results(iter_engines, df, from_schema, to_schema)
-    check_time_shift_timestamps(df, queried, to_schema.time_config)
-    check_time_shift_values(df, queried, from_schema.time_config, to_schema.time_config)
-
-
 @pytest.mark.parametrize("tzinfo", [ZoneInfo("US/Eastern"), None])
 def test_time_interval_shift_different_time_ranges(
     iter_engines: Engine,

--- a/tests/test_mapper_datetime_to_datetime.py
+++ b/tests/test_mapper_datetime_to_datetime.py
@@ -168,6 +168,25 @@ def test_time_interval_shift(
     check_time_shift_values(df, queried, from_schema.time_config, to_schema.time_config)
 
 
+@pytest.mark.parametrize("tzinfo", [ZoneInfo("US/Eastern")])  # , None])
+def test_map_time_resolution(
+    iter_engines: Engine,
+    tzinfo: ZoneInfo | None,
+) -> None:
+    from_schema = get_datetime_schema(
+        2020, tzinfo, TimeIntervalType.PERIOD_BEGINNING, "from_table"
+    )
+    df = generate_datetime_dataframe(from_schema)
+    to_schema = get_datetime_schema(2020, tzinfo, TimeIntervalType.PERIOD_ENDING, "to_table")
+    to_schema.time_config.resolution = timedelta(minutes=30)
+
+    breakpoint()
+
+    queried = get_mapped_results(iter_engines, df, from_schema, to_schema)
+    check_time_shift_timestamps(df, queried, to_schema.time_config)
+    check_time_shift_values(df, queried, from_schema.time_config, to_schema.time_config)
+
+
 @pytest.mark.parametrize("tzinfo", [ZoneInfo("US/Eastern"), None])
 def test_time_interval_shift_different_time_ranges(
     iter_engines: Engine,

--- a/tests/test_mapper_index_time_to_datetime.py
+++ b/tests/test_mapper_index_time_to_datetime.py
@@ -218,7 +218,7 @@ def test_unaligned_time_mapping_without_wrap_time(iter_engines: Engine) -> None:
     src_df, src_schema, dst_schema = data_for_unaligned_time_mapping()
     error = (
         ConflictingInputsError,
-        "Length must match between",
+        "For unchanging time resolution, length must match between",
     )
     run_test(
         iter_engines,


### PR DESCRIPTION
Mapping time resolution is defined by the time resolution in time_config as well as the optional param `resampling_operation` into the mapper function.

Aggregation types:
![image](https://github.com/user-attachments/assets/b6e2ef9b-6e5f-4072-9efd-c1ae61beb310)


Disaggregation types:
![image](https://github.com/user-attachments/assets/8b91c6f8-c666-4b94-ba25-bbc65b1a91eb)
