### PR TITLE
Fix override of scratch_dir

### DIFF
--- a/src/chronify/csv_time_series_parser.py
+++ b/src/chronify/csv_time_series_parser.py
@@ -114,7 +114,7 @@ class CsvTimeSeriesParser:
 
     @staticmethod
     def _read_data_file(data_file: Path) -> pd.DataFrame:
-        return pd.read_csv(data_file, header=0, dtype=COLUMN_DTYPES)
+        return pd.read_csv(data_file, header=0, dtype=COLUMN_DTYPES)  # type: ignore
 
     def _ingest_data(self, data: pd.DataFrame, table_name: str, year: int, length: int) -> None:
         csv_fmt = CsvTimeSeriesFormats.from_columns(data.columns)

--- a/src/chronify/time_series_mapper_base.py
+++ b/src/chronify/time_series_mapper_base.py
@@ -109,6 +109,7 @@ def apply_mapping(
             mapping_schema.name,
             mapping_schema.time_configs,
             if_table_exists="fail",
+            scratch_dir=scratch_dir,
         )
     metadata.reflect(engine, views=True)
 

--- a/src/chronify/time_series_mapper_column_representative_to_datetime.py
+++ b/src/chronify/time_series_mapper_column_representative_to_datetime.py
@@ -87,7 +87,7 @@ class MapperColumnRepresentativeToDatetime(TimeSeriesMapperBase):
         elif isinstance(self._from_time_config, MonthDayHourTimeNTZ):
             df_mapping, mapping_schema = self._create_mdh_mapping()
         elif isinstance(self._from_time_config, YearMonthDayPeriodTimeNTZ):
-            int_mapping = self._intermediate_mapping_ymdp_to_ymdh()
+            int_mapping = self._intermediate_mapping_ymdp_to_ymdh(scratch_dir)
             from_schema = int_mapping
             drop_table = int_mapping.name
             df_mapping, mapping_schema = self._create_ymdh_mapping(
@@ -133,7 +133,7 @@ class MapperColumnRepresentativeToDatetime(TimeSeriesMapperBase):
             msg = "Year is required for mdh time range to be converter to DatetimeRange."
             raise InvalidParameter(msg)
 
-    def _intermediate_mapping_ymdp_to_ymdh(self) -> TableSchema:
+    def _intermediate_mapping_ymdp_to_ymdh(self, scratch_dir: Path | None) -> TableSchema:
         """Convert ymdp to ymdh for intermediate mapping."""
         mapping_table_name = "intermediate_ymdp_to_ymdh"
         period_col = self._from_time_config.hour_columns[0]
@@ -150,6 +150,7 @@ class MapperColumnRepresentativeToDatetime(TimeSeriesMapperBase):
                 mapping_table_name,
                 [self._from_time_config],
                 if_table_exists="replace",
+                scratch_dir=scratch_dir,
             )
 
         self._metadata.reflect(self._engine)


### PR DESCRIPTION
The code was in some cases only writing to the system's temp filesystem. This would fail on the HPC with multiple nodes. The code needs to allow an override that forces use of the shared filesystem.